### PR TITLE
io.github.natty-parser as the group id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>natty-parser</groupId>
+  <groupId>io.github.natty-parser</groupId>
   <artifactId>natty</artifactId>
   <packaging>jar</packaging>
   <version>0.14-SNAPSHOT</version>


### PR DESCRIPTION
Apparently as explained in https://central.sonatype.org/publish/requirements/coordinates/ it's now required to own the domain matching the Maven group id. Since we don't own `natty.org`, we need to use `io.github.natty-parser` as the group id.