### PR TITLE
Fix broken tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Plan / Priorities (as of March 2022):
 
 1. ~~Release version `1.0.0` with (possibly) the same code as the fork root, but under new name, consider renaming packages and artifacts to use `natty-parser` as the moniker, etc.~~
 DONE
-2. Fix the tests (some are failing?).
+2. ~~Fix the tests (some are failing?).~~ DONE
 3. Set up basic technicalities of the fork - Maven release process, CI (Continuous Integration), etc. 
 4. Start accepting contributions (PRs), encourage the community to solve [issues reported in the original repo](https://github.com/joestelmach/natty/issues)
 5. Consider switching to Gradle (as this is a build tool which is modern and I am familiar with)

--- a/src/test/java/org/natty/DateTimeTest.java
+++ b/src/test/java/org/natty/DateTimeTest.java
@@ -2,7 +2,6 @@ package org.natty;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.text.DateFormat;
@@ -25,10 +24,9 @@ public class DateTimeTest extends AbstractTest {
   }
 
   @Test
-  @Ignore("https://github.com/natty-parser/natty/issues/1")
   public void testSpecific() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
-        DateFormat.SHORT).parse("5/19/2012 12:00 am");
+        DateFormat.SHORT).parse("5/19/2012, 12:00 am");
     calendarSource = new CalendarSource(reference);
 
     validateDateTime(reference, "1st oct in the year '89 1300 hours", 10, 1, 1989, 13, 0, 0);
@@ -48,10 +46,9 @@ public class DateTimeTest extends AbstractTest {
   }
 
   @Test
-  @Ignore("https://github.com/natty-parser/natty/issues/1")
   public void testRelative() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
-        DateFormat.SHORT).parse("2/24/2011 12:00 am");
+        DateFormat.SHORT).parse("2/24/2011, 12:00 am");
     calendarSource = new CalendarSource(reference);
 
     validateDateTime(reference, "seven years ago at 3pm", 2, 24, 2004, 15, 0, 0);

--- a/src/test/java/org/natty/RecurrenceTest.java
+++ b/src/test/java/org/natty/RecurrenceTest.java
@@ -8,7 +8,6 @@ import java.util.TimeZone;
 import junit.framework.Assert;
 import org.junit.BeforeClass;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -24,10 +23,9 @@ public class RecurrenceTest extends AbstractTest {
   }
  
   @Test
-  @Ignore("https://github.com/natty-parser/natty/issues/1")
   public void testRelative() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT, 
-        DateFormat.SHORT).parse("3/3/2011 12:00 am");
+        DateFormat.SHORT).parse("3/3/2011, 12:00 am");
     calendarSource = new CalendarSource(reference);
     
     DateGroup group = _parser.parse("every friday until two tuesdays from now", reference).get(0);

--- a/src/test/java/org/natty/ThreadSafetyTest.java
+++ b/src/test/java/org/natty/ThreadSafetyTest.java
@@ -8,7 +8,6 @@ import java.util.TimeZone;
 
 import org.junit.Assert;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.BeforeClass;
 
@@ -29,7 +28,6 @@ public class ThreadSafetyTest extends AbstractTest {
   }
 
   @Test
-  @Ignore("https://github.com/natty-parser/natty/issues/1")
   public void testManyThreads() throws Exception {
     Thread[] threads = new Thread[NUM_OF_THREADS];
     for (int i = 0; i < NUM_OF_THREADS; i++) {
@@ -50,7 +48,7 @@ public class ThreadSafetyTest extends AbstractTest {
     private int baseMinute;
 
     public Tester(int baseMinute) throws Exception {
-      String date = String.format("3/3/2011 1:%02d am", baseMinute);
+      String date = String.format("3/3/2011, 1:%02d am", baseMinute);
       this.referenceDate = dateFormat.parse(date);
       this.baseMinute = baseMinute;
     }

--- a/src/test/java/org/natty/TimeZoneTest.java
+++ b/src/test/java/org/natty/TimeZoneTest.java
@@ -1,7 +1,6 @@
 package org.natty;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.text.DateFormat;
@@ -19,10 +18,9 @@ public class TimeZoneTest extends AbstractTest {
   }
 
   @Test
-  @Ignore("https://github.com/natty-parser/natty/issues/1")
   public void testSpecific() throws Exception {
     Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
-        DateFormat.SHORT).parse("5/19/2012 12:00 am");
+        DateFormat.SHORT).parse("5/19/2012, 12:00 am");
     calendarSource = new CalendarSource(reference);
 
     validateDateTime(reference, "2011-06-17T07:00:00Z", 6, 17, 2011, 3, 0, 0);


### PR DESCRIPTION
Fix #1 

The `SHORT` date/time format used in `java.base.DateFormat` seems to have changed to include a comma between the date and the time portion. 
Found out via using `DateFormat.format(new Date())`.