### PR TITLE
#26 Fix javadoc building

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,12 +15,12 @@ jobs:
         java_version: ['8', '11', '17']
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java_version }}
+          distribution: 'temurin'
+          cache: maven
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,7 @@ jobs:
     name: Java ${{ matrix.java_version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         java_version: ['8', '11', '17']
 

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <additionalparam>-Xdoclint:none</additionalparam>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   
   <distributionManagement>
@@ -217,9 +219,9 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>3.4.1</version>
-	    <configuration>
-	      <doclint>none</doclint>  <!-- Turnoff all checks -->
-	    </configuration>
+            <configuration>
+
+            </configuration>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -86,10 +86,6 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.10.1</version>
-        <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
-        </configuration>
       </plugin>
       
       <!-- clean plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.4.4</version>
+      <version>1.3.4</version>
     </dependency>
     
     <dependency>

--- a/src/main/java/org/natty/DateGroup.java
+++ b/src/main/java/org/natty/DateGroup.java
@@ -31,7 +31,7 @@ public class DateGroup {
 
   /**
    * Adds a date to this group
-   * @param date
+   * @param date the date
    */
   public void addDate(Date date) {
     _dates.add(date);
@@ -77,7 +77,7 @@ public class DateGroup {
 
   /**
    * The line within the fullText this date group is found on
-   * @return
+   * @return line number
    */
   public int getLine() {
     return _line;

--- a/src/main/java/org/natty/Parser.java
+++ b/src/main/java/org/natty/Parser.java
@@ -43,7 +43,7 @@ public class Parser {
 
   /**
    * Creates a new parser using the given time zone as the default
-   * @param defaultTimeZone
+   * @param defaultTimeZone the timezone
    */
   public Parser(TimeZone defaultTimeZone) {
     _defaultTimeZone = defaultTimeZone;
@@ -57,11 +57,10 @@ public class Parser {
   }
   
   /**
-   * Parses the given input value for one or more groups of
-   * date alternatives
+   * Parses the given input value for one or more groups of date alternatives
    * 
-   * @param value
-   * @return
+   * @param value the date tor parse
+   * @return list of date alternatives
    */
   public List<DateGroup> parse(String value) {
     return parse(value, new Date());
@@ -72,9 +71,9 @@ public class Parser {
    * date alternatives with relative dates resolved according
    * to referenceDate
    *
-   * @param value
-   * @param referenceDate
-   * @return
+   * @param value the date string to parse
+   * @param referenceDate the reference date for relative dates
+   * @return list of date alternatives
    */
   public List<DateGroup> parse(String value, Date referenceDate) {
 

--- a/src/main/java/org/natty/Parser.java
+++ b/src/main/java/org/natty/Parser.java
@@ -59,7 +59,7 @@ public class Parser {
   /**
    * Parses the given input value for one or more groups of date alternatives
    * 
-   * @param value the date tor parse
+   * @param value the date to parse
    * @return list of date alternatives
    */
   public List<DateGroup> parse(String value) {

--- a/src/main/java/org/natty/WalkerState.java
+++ b/src/main/java/org/natty/WalkerState.java
@@ -63,8 +63,8 @@ public class WalkerState {
    * seeks to a specified day of the week in the past or future.
    * 
    * @param direction the direction to seek: two possibilities 
-   *    '<' go backward 
-   *    '>' go forward
+   *    '&lt;' go backward
+   *    '&gt;' go forward
    *    
    * @param seekType the type of seek to perform (by_day or by_week)
    *     by_day means we seek to the very next occurrence of the given day
@@ -142,8 +142,8 @@ public class WalkerState {
   }
   
   /**
-   * 
-   * @param year
+   * Seek to the given year
+   * @param year the year to seek to.
    */
   public void seekToYear(String year) {
     int yearInt = Integer.parseInt(year);
@@ -158,8 +158,8 @@ public class WalkerState {
    * seeks to a particular month
    * 
    * @param direction the direction to seek: two possibilities 
-   *    '<' go backward 
-   *    '>' go forward
+   *    '&lt;' go backward
+   *    '&gt;' go forward
    *    
    * @param seekAmount the amount to seek.  Must be guaranteed to parse as an integer
    *     
@@ -197,12 +197,12 @@ public class WalkerState {
    * seeks by a span of time (weeks, months, etc)
    * 
    * @param direction the direction to seek: two possibilities 
-   *    '<' go backward 
-   *    '>' go forward
+   *    '&lt;' go backward
+   *    '&gt;' go forward
    *    
    * @param seekAmount the amount to seek.  Must be guaranteed to parse as an integer
    *     
-   * @param span
+   * @param span the span to seek by, one of DAY, WEEK, MONTH, YEAR, HOUR, MINUTE, SECOND
    */
   public void seekBySpan(String direction, String seekAmount, String span) {
     if(span.startsWith(SEEK_PREFIX)) span = span.substring(3);
@@ -234,12 +234,7 @@ public class WalkerState {
       null;
     if(field > 0) _calendar.add(field, seekAmountInt * sign);
   }
-  
-  /**
-   * 
-   * @param index
-   * @param dayOfWeek
-   */
+
   public void setDayOfWeekIndex(String index, String dayOfWeek) {
     int indexInt = Integer.parseInt(index);
     assert(indexInt > 0 && indexInt < 6);
@@ -314,7 +309,7 @@ public class WalkerState {
   }
   
   /**
-   * Sets the the time of day
+   * Sets the time of day
    * 
    * @param hours the hours to set.  Must be guaranteed to parse as an 
    *     integer between 0 and 23
@@ -395,9 +390,9 @@ public class WalkerState {
 
   /**
    * Seeks to the given holiday within the given year
-   * 
-   * @param holidayString
-   * @param yearString
+   * @see Holiday
+   * @param holidayString the name of the holiday as per Holiday enum
+   * @param yearString the year
    */
   public void seekToHolidayYear(String holidayString, String yearString) {
     Holiday holiday = Holiday.valueOf(holidayString);
@@ -423,8 +418,8 @@ public class WalkerState {
   /**
    * Seeks to the given season within the given year
    * 
-   * @param seasonString
-   * @param yearString
+   * @param seasonString The season to seek to
+   * @param yearString The year
    */
   public void seekToSeasonYear(String seasonString, String yearString) {
     Season season = Season.valueOf(seasonString);


### PR DESCRIPTION
Setting the source and target version to 8 - I believe that should be the target for now unless there is a valid reason to depend on a newer JDK.

IMHO generated code should not be part of Javadoc. It is now.
I'm more familar with gradle but I could look into ingoring that in Javadoc if people feel it makes sense.
