### PR TITLE
#1 Fix unit tests on JDK 8 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,12 @@
       <version>1.7.33</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.4.4</version>
+    </dependency>
     
     <dependency>
       <groupId>junit</groupId>

--- a/src/test/java/org/natty/DateTimeTest.java
+++ b/src/test/java/org/natty/DateTimeTest.java
@@ -4,7 +4,9 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -24,9 +26,9 @@ public class DateTimeTest extends AbstractTest {
   }
 
   @Test
-  public void testSpecific() throws Exception {
-    Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
-        DateFormat.SHORT).parse("5/19/2012, 12:00 am");
+  public void testSpecific()  {
+    final LocalDateTime refDateTime = LocalDateTime.of(2012, 5, 19, 12, 00, 00);
+    Date reference = Timestamp.valueOf(refDateTime);
     calendarSource = new CalendarSource(reference);
 
     validateDateTime(reference, "1st oct in the year '89 1300 hours", 10, 1, 1989, 13, 0, 0);
@@ -46,9 +48,9 @@ public class DateTimeTest extends AbstractTest {
   }
 
   @Test
-  public void testRelative() throws Exception {
-    Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
-        DateFormat.SHORT).parse("2/24/2011, 12:00 am");
+  public void testRelative() {
+    final LocalDateTime refDateTime = LocalDateTime.of(2011, 2, 24, 0, 0, 0);
+    Date reference = Timestamp.valueOf(refDateTime);
     calendarSource = new CalendarSource(reference);
 
     validateDateTime(reference, "seven years ago at 3pm", 2, 24, 2004, 15, 0, 0);

--- a/src/test/java/org/natty/RecurrenceTest.java
+++ b/src/test/java/org/natty/RecurrenceTest.java
@@ -1,6 +1,8 @@
 package org.natty;
 
+import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -24,8 +26,9 @@ public class RecurrenceTest extends AbstractTest {
  
   @Test
   public void testRelative() throws Exception {
-    Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT, 
-        DateFormat.SHORT).parse("3/3/2011, 12:00 am");
+
+    final LocalDateTime refDateTime = LocalDateTime.of(2011, 3, 3, 12, 00, 00);
+    Date reference = Timestamp.valueOf(refDateTime);
     calendarSource = new CalendarSource(reference);
     
     DateGroup group = _parser.parse("every friday until two tuesdays from now", reference).get(0);

--- a/src/test/java/org/natty/ThreadSafetyTest.java
+++ b/src/test/java/org/natty/ThreadSafetyTest.java
@@ -1,6 +1,8 @@
 package org.natty;
 
+import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,14 +50,14 @@ public class ThreadSafetyTest extends AbstractTest {
     private int baseMinute;
 
     public Tester(int baseMinute) throws Exception {
-      String date = String.format("3/3/2011, 1:%02d am", baseMinute);
-      this.referenceDate = dateFormat.parse(date);
+      final LocalDateTime refDateTime = LocalDateTime.of(2011, 3, 3, 1, baseMinute, 0);
+      this.referenceDate = Timestamp.valueOf(refDateTime);
       this.baseMinute = baseMinute;
     }
 
     public void run() {
       try {
-        // Immitate some long running task.
+        // Imitate some long running task.
         Thread.sleep(100);
       } catch (Exception e) { }
       String newDate = "4/4/2012";

--- a/src/test/java/org/natty/TimeZoneTest.java
+++ b/src/test/java/org/natty/TimeZoneTest.java
@@ -3,7 +3,9 @@ package org.natty;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.sql.Timestamp;
 import java.text.DateFormat;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
@@ -19,8 +21,8 @@ public class TimeZoneTest extends AbstractTest {
 
   @Test
   public void testSpecific() throws Exception {
-    Date reference = DateFormat.getDateTimeInstance(DateFormat.SHORT,
-        DateFormat.SHORT).parse("5/19/2012, 12:00 am");
+    final LocalDateTime refDateTime = LocalDateTime.of(2012, 5, 19, 12, 00, 00);
+    Date reference = Timestamp.valueOf(refDateTime);
     calendarSource = new CalendarSource(reference);
 
     validateDateTime(reference, "2011-06-17T07:00:00Z", 6, 17, 2011, 3, 0, 0);

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Directly create date instead of relying on parsing