### PR TITLE
Remove logback dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,7 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>1.3.4</version>
+      <scope>test</scope>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
There is no need to have a runtime dependency on logback.