### PR TITLE
 Support for 'fortnight'

### DIFF
--- a/issues.md
+++ b/issues.md
@@ -99,79 +99,79 @@ The issues are grouped into rough categories to make it possible to prioritise t
 
 ## Feature requests
 
-| ID                                                      | Title                                                                                                                       |
-|---------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
-| [#276](https://github.com/joestelmach/natty/issues/276) | Parsing of quarter not supported                                                                                            |
-| [#270](https://github.com/joestelmach/natty/issues/270) | support canonical timezone id (not just abbreviations)                                                                      |
-| [#269](https://github.com/joestelmach/natty/issues/269) | Support for countries which use DD MM YYYY                                                                                  |
-| [#259](https://github.com/joestelmach/natty/issues/259) | Can't parse time fields like "60s"                                                                                          |
-| [#258](https://github.com/joestelmach/natty/issues/258) | Upgrade to Antlr4                                                                                                           |
-| [#256](https://github.com/joestelmach/natty/issues/256) | Year is added to current year 2018 jan 15 gives year 4036-01-01 3pm utc [other format]                                      |
-| [#255](https://github.com/joestelmach/natty/issues/255) | Year references would be nice to match                                                                                      |
-| [#264](https://github.com/joestelmach/natty/issues/264) | "23rd" not getting parsed. Expected result is current_MM/23/current_YYYY                                                    |
-| [#249](https://github.com/joestelmach/natty/issues/249) | Is it possible to make natty multilingual?                                                                                  |
-| [#248](https://github.com/joestelmach/natty/issues/248) | Feature request                                                                                                             |
-| [#245](https://github.com/joestelmach/natty/issues/245) | Feature Request: Set date format locale on call                                                                             |
-| [#239](https://github.com/joestelmach/natty/issues/239) | A fortnight happens to be absent from Natty's vocabulary                                                                    |
-| [#235](https://github.com/joestelmach/natty/issues/235) | java.lang.IllegalArgumentException: No enum constant com.joestelmach.natty.Holiday.INAUGURATION_DAY                         |
-| [#233](https://github.com/joestelmach/natty/issues/233) | Parsing week numbers                                                                                                        |
-| [#231](https://github.com/joestelmach/natty/issues/231) | Couple days from now / next leap year                                                                                       |
-| [#226](https://github.com/joestelmach/natty/issues/226) | RFC 2822 Support                                                                                                            |
-| [#223](https://github.com/joestelmach/natty/issues/223) | Add support for several languages                                                                                           |
-| [#222](https://github.com/joestelmach/natty/issues/222) | time period recognition                                                                                                     |
-| [#221](https://github.com/joestelmach/natty/issues/221) | Add time grain for date parsed                                                                                              |
-| [#220](https://github.com/joestelmach/natty/issues/220) | Add support for "1h2m" format?                                                                                              |
-| [#216](https://github.com/joestelmach/natty/issues/216) | First Quarter / Q1-Q3                                                                                                       |
-| [#205](https://github.com/joestelmach/natty/issues/205) | Unable to distinguish time range                                                                                            |
-| [#200](https://github.com/joestelmach/natty/issues/200) | some day in the feature                                                                                                     |
-| [#198](https://github.com/joestelmach/natty/issues/198) | 21st Oct last year is not supported                                                                                         |
-| [#197](https://github.com/joestelmach/natty/issues/197) | Not accepting the week after                                                                                                |
-| [#191](https://github.com/joestelmach/natty/issues/191) | "Mid August" parses to Aug. 01                                                                                              |
-| [#187](https://github.com/joestelmach/natty/issues/187) | Unable to determine the following date type                                                                                 |
-| [#186](https://github.com/joestelmach/natty/issues/186) | Enhancement: Locale/Internationalization support?                                                                           |
-| [#185](https://github.com/joestelmach/natty/issues/185) | Can't parse date from this :NT INT INST 2005 06 08 Let ECGD du 29 mars.pdf                                                  |
-| [#183](https://github.com/joestelmach/natty/issues/183) | quarter is not parsed                                                                                                       |
-| [#182](https://github.com/joestelmach/natty/issues/182) | 25th of every month is not parsed                                                                                           |
-| [#181](https://github.com/joestelmach/natty/issues/181) | Can't parse short format: 3h ago                                                                                            |
-| [#177](https://github.com/joestelmach/natty/issues/177) | Doesn't recognize "Last quarter"                                                                                            |
-| [#172](https://github.com/joestelmach/natty/issues/172) | Does not recognize 'previous' keyword                                                                                       |
-| [#168](https://github.com/joestelmach/natty/issues/168) | Natty ignores milliseconds                                                                                                  |
-| [#159](https://github.com/joestelmach/natty/issues/159) | parsing text with numbers                                                                                                   |
-| [#153](https://github.com/joestelmach/natty/issues/153) | Date ranges?                                                                                                                |
-| [#150](https://github.com/joestelmach/natty/issues/150) | "the beginning of (next) year"                                                                                              |
-| [#140](https://github.com/joestelmach/natty/issues/140) | recognize before month                                                                                                      |
-| [#138](https://github.com/joestelmach/natty/issues/138) | Quarters                                                                                                                    |
-| [#134](https://github.com/joestelmach/natty/issues/134) | Incorrect parsing for dd-mm-yyyy and similar                                                                                |
-| [#132](https://github.com/joestelmach/natty/issues/132) | Handle "Next Business Day" and "As Soon As Possible"                                                                        |
-| [#129](https://github.com/joestelmach/natty/issues/129) | How to refer to beginning of (computer) time?                                                                               |
-| [#123](https://github.com/joestelmach/natty/issues/123) | Parsing strings with only year information                                                                                  |
-| [#122](https://github.com/joestelmach/natty/issues/122) | How to translate natty recognition in other languages                                                                       |
-| [#121](https://github.com/joestelmach/natty/issues/121) | prefixes "3 days from <a date>" doesn't seem to work                                                                        |
-| [#120](https://github.com/joestelmach/natty/issues/120) | Date range doesn't take into account day of week                                                                            |
-| [#114](https://github.com/joestelmach/natty/issues/114) | Relative dates with respect to another date rather than now                                                                 |
-| [#110](https://github.com/joestelmach/natty/issues/110) | "JUNE 9TH - JUNE 23RD, 2014" is parsed as 06/09/201*5* - 06/23/2014                                                         |
-| [#106](https://github.com/joestelmach/natty/issues/106) | how to parse twelve to ten?                                                                                                 |
-| [#105](https://github.com/joestelmach/natty/issues/105) | java time zoneddatetime to string should be supported                                                                       |
-| [#93](https://github.com/joestelmach/natty/issues/93)   | need week end and work day aliases as we have for holidays                                                                  |
-| [#80](https://github.com/joestelmach/natty/issues/80)   | Four score and ten years ago                                                                                                |
-| [#77](https://github.com/joestelmach/natty/issues/77)   | Recalculate a time- inferred date                                                                                           |
-| [#69](https://github.com/joestelmach/natty/issues/69)   | Year bias...                                                                                                                |
-| [#64](https://github.com/joestelmach/natty/issues/64)   | How to parse dates of format DD/MM/YYYY?                                                                                    |
-| [#57](https://github.com/joestelmach/natty/issues/57)   | Fails to parse day of month (eg: "the 21st")                                                                                |
-| [#53](https://github.com/joestelmach/natty/issues/53)   | Include possible date/time range ?                                                                                          |
-| [#48](https://github.com/joestelmach/natty/issues/48)   | I18n support - different languages/countries                                                                                |
-| [#47](https://github.com/joestelmach/natty/issues/47)   | Make CalendarSource.setBaseDate an instance method                                                                          |
-| [#44](https://github.com/joestelmach/natty/issues/44)   | friendlier time rules                                                                                                       |
-| [#41](https://github.com/joestelmach/natty/issues/41)   | Feature: Future dates only option                                                                                           |
-| [#26](https://github.com/joestelmach/natty/issues/26)   | Not Parsing "March 9-13, 2012" properly                                                                                     |
-| [#25](https://github.com/joestelmach/natty/issues/25)   | can not parse "2011-09-12T13:55:00.004+02:00"                                                                               |
-| [#23](https://github.com/joestelmach/natty/issues/23)   | "each sunday in march" did not parse                                                                                        |
-| [#21](https://github.com/joestelmach/natty/issues/21)   | French Dates Like 07-10-2011                                                                                                |
-| [#20](https://github.com/joestelmach/natty/issues/20)   | German Dates Like 07.10.2011                                                                                                |
-| [#17](https://github.com/joestelmach/natty/issues/17)   | Feature requests: More date ranges, custom event support                                                                    |
-| [#16](https://github.com/joestelmach/natty/issues/16)   | Cannot parse Sat., Sept. 24, 10:30 a.m.-9 p.m. format                                                                       |
-| [#6](https://github.com/joestelmach/natty/issues/6)     | Add time precision option                                                                                                   |
-| [#3](https://github.com/joestelmach/natty/issues/3)     | UK-formatted dates won't parse                                                                                              |
+| ID                                                          | Title                                                                                                                       |
+|-------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| [#276](https://github.com/joestelmach/natty/issues/276)     | Parsing of quarter not supported                                                                                            |
+| [#270](https://github.com/joestelmach/natty/issues/270)     | support canonical timezone id (not just abbreviations)                                                                      |
+| [#269](https://github.com/joestelmach/natty/issues/269)     | Support for countries which use DD MM YYYY                                                                                  |
+| [#259](https://github.com/joestelmach/natty/issues/259)     | Can't parse time fields like "60s"                                                                                          |
+| [#258](https://github.com/joestelmach/natty/issues/258)     | Upgrade to Antlr4                                                                                                           |
+| [#256](https://github.com/joestelmach/natty/issues/256)     | Year is added to current year 2018 jan 15 gives year 4036-01-01 3pm utc [other format]                                      |
+| [#255](https://github.com/joestelmach/natty/issues/255)     | Year references would be nice to match                                                                                      |
+| [#264](https://github.com/joestelmach/natty/issues/264)     | "23rd" not getting parsed. Expected result is current_MM/23/current_YYYY                                                    |
+| [#249](https://github.com/joestelmach/natty/issues/249)     | Is it possible to make natty multilingual?                                                                                  |
+| [#248](https://github.com/joestelmach/natty/issues/248)     | Feature request                                                                                                             |
+| [#245](https://github.com/joestelmach/natty/issues/245)     | Feature Request: Set date format locale on call                                                                             |
+| [~~#239~~](https://github.com/joestelmach/natty/issues/239) | A fortnight happens to be absent from Natty's vocabulary                                                                    |
+| [#235](https://github.com/joestelmach/natty/issues/235)     | java.lang.IllegalArgumentException: No enum constant com.joestelmach.natty.Holiday.INAUGURATION_DAY                         |
+| [#233](https://github.com/joestelmach/natty/issues/233)     | Parsing week numbers                                                                                                        |
+| [#231](https://github.com/joestelmach/natty/issues/231)     | Couple days from now / next leap year                                                                                       |
+| [#226](https://github.com/joestelmach/natty/issues/226)     | RFC 2822 Support                                                                                                            |
+| [#223](https://github.com/joestelmach/natty/issues/223)     | Add support for several languages                                                                                           |
+| [#222](https://github.com/joestelmach/natty/issues/222)     | time period recognition                                                                                                     |
+| [#221](https://github.com/joestelmach/natty/issues/221)     | Add time grain for date parsed                                                                                              |
+| [#220](https://github.com/joestelmach/natty/issues/220)     | Add support for "1h2m" format?                                                                                              |
+| [#216](https://github.com/joestelmach/natty/issues/216)     | First Quarter / Q1-Q3                                                                                                       |
+| [#205](https://github.com/joestelmach/natty/issues/205)     | Unable to distinguish time range                                                                                            |
+| [#200](https://github.com/joestelmach/natty/issues/200)     | some day in the feature                                                                                                     |
+| [#198](https://github.com/joestelmach/natty/issues/198)     | 21st Oct last year is not supported                                                                                         |
+| [#197](https://github.com/joestelmach/natty/issues/197)     | Not accepting the week after                                                                                                |
+| [#191](https://github.com/joestelmach/natty/issues/191)     | "Mid August" parses to Aug. 01                                                                                              |
+| [#187](https://github.com/joestelmach/natty/issues/187)     | Unable to determine the following date type                                                                                 |
+| [#186](https://github.com/joestelmach/natty/issues/186)     | Enhancement: Locale/Internationalization support?                                                                           |
+| [#185](https://github.com/joestelmach/natty/issues/185)     | Can't parse date from this :NT INT INST 2005 06 08 Let ECGD du 29 mars.pdf                                                  |
+| [#183](https://github.com/joestelmach/natty/issues/183)     | quarter is not parsed                                                                                                       |
+| [#182](https://github.com/joestelmach/natty/issues/182)     | 25th of every month is not parsed                                                                                           |
+| [#181](https://github.com/joestelmach/natty/issues/181)     | Can't parse short format: 3h ago                                                                                            |
+| [#177](https://github.com/joestelmach/natty/issues/177)     | Doesn't recognize "Last quarter"                                                                                            |
+| [#172](https://github.com/joestelmach/natty/issues/172)     | Does not recognize 'previous' keyword                                                                                       |
+| [#168](https://github.com/joestelmach/natty/issues/168)     | Natty ignores milliseconds                                                                                                  |
+| [#159](https://github.com/joestelmach/natty/issues/159)     | parsing text with numbers                                                                                                   |
+| [#153](https://github.com/joestelmach/natty/issues/153)     | Date ranges?                                                                                                                |
+| [#150](https://github.com/joestelmach/natty/issues/150)     | "the beginning of (next) year"                                                                                              |
+| [#140](https://github.com/joestelmach/natty/issues/140)     | recognize before month                                                                                                      |
+| [#138](https://github.com/joestelmach/natty/issues/138)     | Quarters                                                                                                                    |
+| [#134](https://github.com/joestelmach/natty/issues/134)     | Incorrect parsing for dd-mm-yyyy and similar                                                                                |
+| [#132](https://github.com/joestelmach/natty/issues/132)     | Handle "Next Business Day" and "As Soon As Possible"                                                                        |
+| [#129](https://github.com/joestelmach/natty/issues/129)     | How to refer to beginning of (computer) time?                                                                               |
+| [#123](https://github.com/joestelmach/natty/issues/123)     | Parsing strings with only year information                                                                                  |
+| [#122](https://github.com/joestelmach/natty/issues/122)     | How to translate natty recognition in other languages                                                                       |
+| [#121](https://github.com/joestelmach/natty/issues/121)     | prefixes "3 days from <a date>" doesn't seem to work                                                                        |
+| [#120](https://github.com/joestelmach/natty/issues/120)     | Date range doesn't take into account day of week                                                                            |
+| [#114](https://github.com/joestelmach/natty/issues/114)     | Relative dates with respect to another date rather than now                                                                 |
+| [#110](https://github.com/joestelmach/natty/issues/110)     | "JUNE 9TH - JUNE 23RD, 2014" is parsed as 06/09/201*5* - 06/23/2014                                                         |
+| [#106](https://github.com/joestelmach/natty/issues/106)     | how to parse twelve to ten?                                                                                                 |
+| [#105](https://github.com/joestelmach/natty/issues/105)     | java time zoneddatetime to string should be supported                                                                       |
+| [#93](https://github.com/joestelmach/natty/issues/93)       | need week end and work day aliases as we have for holidays                                                                  |
+| [#80](https://github.com/joestelmach/natty/issues/80)       | Four score and ten years ago                                                                                                |
+| [#77](https://github.com/joestelmach/natty/issues/77)       | Recalculate a time- inferred date                                                                                           |
+| [#69](https://github.com/joestelmach/natty/issues/69)       | Year bias...                                                                                                                |
+| [#64](https://github.com/joestelmach/natty/issues/64)       | How to parse dates of format DD/MM/YYYY?                                                                                    |
+| [#57](https://github.com/joestelmach/natty/issues/57)       | Fails to parse day of month (eg: "the 21st")                                                                                |
+| [#53](https://github.com/joestelmach/natty/issues/53)       | Include possible date/time range ?                                                                                          |
+| [#48](https://github.com/joestelmach/natty/issues/48)       | I18n support - different languages/countries                                                                                |
+| [#47](https://github.com/joestelmach/natty/issues/47)       | Make CalendarSource.setBaseDate an instance method                                                                          |
+| [#44](https://github.com/joestelmach/natty/issues/44)       | friendlier time rules                                                                                                       |
+| [#41](https://github.com/joestelmach/natty/issues/41)       | Feature: Future dates only option                                                                                           |
+| [#26](https://github.com/joestelmach/natty/issues/26)       | Not Parsing "March 9-13, 2012" properly                                                                                     |
+| [#25](https://github.com/joestelmach/natty/issues/25)       | can not parse "2011-09-12T13:55:00.004+02:00"                                                                               |
+| [#23](https://github.com/joestelmach/natty/issues/23)       | "each sunday in march" did not parse                                                                                        |
+| [#21](https://github.com/joestelmach/natty/issues/21)       | French Dates Like 07-10-2011                                                                                                |
+| [#20](https://github.com/joestelmach/natty/issues/20)       | German Dates Like 07.10.2011                                                                                                |
+| [#17](https://github.com/joestelmach/natty/issues/17)       | Feature requests: More date ranges, custom event support                                                                    |
+| [#16](https://github.com/joestelmach/natty/issues/16)       | Cannot parse Sat., Sept. 24, 10:30 a.m.-9 p.m. format                                                                       |
+| [#6](https://github.com/joestelmach/natty/issues/6)         | Add time precision option                                                                                                   |
+| [#3](https://github.com/joestelmach/natty/issues/3)         | UK-formatted dates won't parse                                                                                              |
 
 ## Misc
 

--- a/issues.md
+++ b/issues.md
@@ -7,13 +7,13 @@ The issues are grouped into rough categories to make it possible to prioritise t
 
 | ID                                                          | Title                                                                                                       |
 |-------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
-| [~~#278~~](https://github.com/joestelmach/natty/issues/278)     | 'last easter' gives NPE since 2021                                                                          |
+| [~~#278~~](https://github.com/joestelmach/natty/issues/278) | 'last easter' gives NPE since 2021                                                                          |
 | [#277](https://github.com/joestelmach/natty/issues/277)     | Cant parse this oddly specific string.                                                                      |
-| [~~#263~~](https://github.com/joestelmach/natty/issues/263)     | "Christma-eve" before 2000 throws NPE                                                                       |
+| [~~#263~~](https://github.com/joestelmach/natty/issues/263) | "Christma-eve" before 2000 throws NPE                                                                       |
 | [#246](https://github.com/joestelmach/natty/issues/246)     | Could not parse input org.antlr.runtime.EarlyExitException: null                                            |
 | [~~#238~~](https://github.com/joestelmach/natty/issues/238) | natty line 1:23 no viable alternative at input '4' - Just override the emitErrorMessage method @joestelmach |
 | [#236](https://github.com/joestelmach/natty/issues/236)     | java.lang.NullPointerException                                                                                              |
-| [#234](https://github.com/joestelmach/natty/issues/234)     | NullPointerException                                                                                                        |
+| [~~#234~~](https://github.com/joestelmach/natty/issues/234) | NullPointerException                                                                                                        |
 | [#193](https://github.com/joestelmach/natty/issues/193)     | NumberFormatException                                                                                                       |
 | [#190](https://github.com/joestelmach/natty/issues/190)     | NullPointerExceptions                                                                                                       |
 | [#162](https://github.com/joestelmach/natty/issues/162)     | NPE / NumberFormatExceptions in WalkerState on Seasons and year seaks with miscalculated target year                        |

--- a/pom.xml
+++ b/pom.xml
@@ -287,5 +287,13 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- somewhy we switched to logback -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.3.14</version><!-- latest java 8 compatible version -->
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/src/main/antlr3/org/natty/generated/DateLexer.g
+++ b/src/main/antlr3/org/natty/generated/DateLexer.g
@@ -44,6 +44,7 @@ HOUR   : 'hour'   | 'hours'   | 'hr' DOT?  | 'hrs' DOT?;
 MINUTE : 'minute' | 'minutes' | 'min' DOT? | 'mins' DOT?;
 DAY    : 'day'    | 'days' ;
 WEEK   : 'week'   | 'weeks'   | 'wks' DOT?;
+FORTNIGHT   : 'fortnight'   | 'fortnights'   DOT?;
 MONTH  : 'month'  | 'months';
 YEAR   : 'year'   | 'year' SINGLE_QUOTE? 's' | 'yrs' DOT?;
 

--- a/src/main/antlr3/org/natty/generated/DateParser.g
+++ b/src/main/antlr3/org/natty/generated/DateParser.g
@@ -484,6 +484,24 @@ explicit_relative_week_seek
       -> ^(SEEK DIRECTION[">"] SEEK_BY["by_day"] INT["2"] SPAN["week"])
   ;
 
+ explicit_relative_fortnight_seek
+  // after next
+  : AFTER WHITE_SPACE NEXT
+      -> ^(SEEK DIRECTION[">"] SEEK_BY["by_day"] INT["2"] SPAN["fortnight"])
+
+  // before last
+  | BEFORE WHITE_SPACE LAST
+      -> ^(SEEK DIRECTION["<"] SEEK_BY["by_day"] INT["2"] SPAN["fortnight"])
+
+  // 2 fortnights ago, tuesday of 3 fortnights from now
+  | spelled_or_int_optional_prefix WHITE_SPACE FORTNIGHT WHITE_SPACE relative_date_suffix
+      -> ^(SEEK relative_date_suffix spelled_or_int_optional_prefix SPAN["fortnight"])
+
+  // the week after next
+  | THE WHITE_SPACE FORTNIGHT WHITE_SPACE AFTER WHITE_SPACE NEXT
+      -> ^(SEEK DIRECTION[">"] SEEK_BY["by_day"] INT["2"] SPAN["fortnight"])
+  ;
+
 explicit_day_of_month_part
   // first of, 10th of, 31st of,
   : (THE WHITE_SPACE)? relaxed_day_of_month day_of_month_suffix?
@@ -641,6 +659,7 @@ relative_time_suffix_anchor
 relative_date_span
   : DAY   -> SPAN["day"]
   | WEEK  -> SPAN["week"]
+  | FORTNIGHT  -> SPAN["fortnight"]
   | MONTH -> SPAN["month"]
   | YEAR  -> SPAN["year"]
   ;

--- a/src/main/antlr3/org/natty/generated/DateWalker.g
+++ b/src/main/antlr3/org/natty/generated/DateWalker.g
@@ -44,104 +44,104 @@ options {
 parse
   : date_time_alternative recurrence?
   ;
-  
+
 recurrence
-  @init { 
+  @init {
     _walkerState.setRecurring();
   }
   : ^(RECURRENCE date_time?{ _walkerState.captureDateTime(); })
   ;
-  
+
 date_time_alternative
   : ^(DATE_TIME_ALTERNATIVE date_time+)
   ;
 
 date_time
   @after {
-    _walkerState.captureDateTime(); 
+    _walkerState.captureDateTime();
   }
   : ^(DATE_TIME date? time?)
-  ;  
-  
+  ;
+
 date
-  : relative_date 
+  : relative_date
   | explicit_date
   ;
-  
+
 relative_date
   : ^(RELATIVE_DATE seek* explicit_seek*)
   ;
-  
+
 week_index
-  : ^(WEEK_INDEX index=INT ^(DAY_OF_WEEK day=INT))
+  : ^(WEEK_INDEX index=INT ^(DAY_OF_ day=INT))
     {_walkerState.setDayOfWeekIndex($index.text, $day.text);}
   ;
-  
+
 explicit_date
-  : ^(EXPLICIT_DATE ^(MONTH_OF_YEAR month=INT) ^(DAY_OF_MONTH dom=INT) 
+  : ^(EXPLICIT_DATE ^(MONTH_OF_YEAR month=INT) ^(DAY_OF_MONTH dom=INT)
         (^(DAY_OF_WEEK dow=INT))? (^(YEAR_OF year=INT))?)
     {_walkerState.setExplicitDate($month.text, $dom.text, $dow.text, $year.text);}
   ;
-  
+
 time
   : explicit_time
   | relative_time
   ;
-  
+
 explicit_time
   : ^(EXPLICIT_TIME ^(HOURS_OF_DAY hours=INT) (^(MINUTES_OF_HOUR minutes=INT))?
         (^(SECONDS_OF_MINUTE seconds=INT))? AM_PM? (zone=ZONE | zone=ZONE_OFFSET)?)
     {_walkerState.setExplicitTime($hours.text, $minutes.text, $seconds.text, $AM_PM.text, $zone.text);}
   ;
-  
+
 relative_time
   : ^(RELATIVE_TIME seek)
   ;
-  
+
 seek
   : ^(SEEK DIRECTION by=SEEK_BY amount=INT ^(DAY_OF_WEEK day=INT)  date?)
     {_walkerState.seekToDayOfWeek($DIRECTION.text, $by.text, $amount.text, $day.text);}
-    
+
   | ^(SEEK DIRECTION SEEK_BY amount=INT ^(MONTH_OF_YEAR month=INT))
     {_walkerState.seekToMonth($DIRECTION.text, $amount.text, $month.text);}
-  
+
   | ^(SEEK DIRECTION SEEK_BY (explicit_seek | relative_date)? INT SPAN)
     {_walkerState.seekBySpan($DIRECTION.text, $INT.text, $SPAN.text);}
-  
+
   | ^(SEEK DIRECTION SEEK_BY INT date)
     {_walkerState.seekBySpan($DIRECTION.text, $INT.text, $SEEK_BY.text);}
-    
+
   | ^(SEEK DIRECTION SEEK_BY INT HOLIDAY)
     {_walkerState.seekToHoliday($HOLIDAY.text, $DIRECTION.text, $INT.text);}
-    
+
   | ^(SEEK DIRECTION SEEK_BY INT SEASON)
     {_walkerState.seekToSeason($SEASON.text, $DIRECTION.text, $INT.text);}
   ;
-  
+
 explicit_seek
   : ^(EXPLICIT_SEEK ^(MONTH_OF_YEAR day=INT))
     {_walkerState.seekToMonth(">", "0", $day.text);}
-    
+
   | ^(EXPLICIT_SEEK ^(DAY_OF_MONTH month=INT))
     {_walkerState.seekToDayOfMonth($month.text);}
-    
+
   | ^(EXPLICIT_SEEK ^(DAY_OF_WEEK day=INT))
     {_walkerState.seekToDayOfWeek(">", "by_week", "0", $day.text);}
-    
+
   | ^(EXPLICIT_SEEK ^(DAY_OF_YEAR day=INT))
     {_walkerState.seekToDayOfYear($day.text);}
-    
+
   | ^(EXPLICIT_SEEK ^(YEAR_OF year=INT))
     {_walkerState.seekToYear($year.text);}
-    
+
   | ^(EXPLICIT_SEEK HOLIDAY ^(YEAR_OF year=INT))
     {_walkerState.seekToHolidayYear($HOLIDAY.text, $year.text);}
-    
+
   | ^(EXPLICIT_SEEK SEASON ^(YEAR_OF year=INT))
     {_walkerState.seekToSeasonYear($SEASON.text, $year.text);}
-    
+
   | ^(EXPLICIT_SEEK index=INT ^(DAY_OF_WEEK day=INT))
     {_walkerState.setDayOfWeekIndex($index.text, $day.text);}
-    
+
   | ^(EXPLICIT_SEEK explicit_time)
-  ;  
+  ;

--- a/src/main/antlr3/org/natty/generated/DateWalker.g
+++ b/src/main/antlr3/org/natty/generated/DateWalker.g
@@ -112,10 +112,22 @@ seek
     {_walkerState.seekBySpan($DIRECTION.text, $INT.text, $SEEK_BY.text);}
 
   | ^(SEEK DIRECTION SEEK_BY INT HOLIDAY)
-    {_walkerState.seekToHoliday($HOLIDAY.text, $DIRECTION.text, $INT.text);}
+    { try {
+        _walkerState.seekToHoliday($HOLIDAY.text, $DIRECTION.text, $INT.text);
+        } catch (org.natty.eventsearchers.EventNotAvailable ise) {
+          throw new RecognitionException(input);
+        }
+     }
 
   | ^(SEEK DIRECTION SEEK_BY INT SEASON)
-    {_walkerState.seekToSeason($SEASON.text, $DIRECTION.text, $INT.text);}
+    {
+      try {
+       _walkerState.seekToSeason($SEASON.text, $DIRECTION.text, $INT.text);
+       } catch (org.natty.eventsearchers.EventNotAvailable ise) {
+          throw new RecognitionException(input);
+        }
+
+       }
   ;
 
 explicit_seek

--- a/src/main/antlr3/org/natty/generated/DateWalker.g
+++ b/src/main/antlr3/org/natty/generated/DateWalker.g
@@ -73,7 +73,7 @@ relative_date
   ;
 
 week_index
-  : ^(WEEK_INDEX index=INT ^(DAY_OF_ day=INT))
+  : ^(WEEK_INDEX index=INT ^(DAY_OF_WEEK day=INT))
     {_walkerState.setDayOfWeekIndex($index.text, $day.text);}
   ;
 

--- a/src/main/java/org/natty/CalendarSource.java
+++ b/src/main/java/org/natty/CalendarSource.java
@@ -5,7 +5,7 @@ import java.util.GregorianCalendar;
 
 /**
  * Responsible for generating new Calendars that represent
- * the current point in time.  This is necessary so we can
+ * the current point in time.  This is necessary, so we can
  * manipulate what the software thinks is the 'current'
  * time, which may be different from the system time
  *
@@ -23,6 +23,9 @@ public class CalendarSource {
   }
 
   public GregorianCalendar getCurrentCalendar() {
+    if (referenceDate == null) {
+      return null;
+    }
     GregorianCalendar calendar = new GregorianCalendar();
     calendar.setTime(referenceDate);
     return calendar;

--- a/src/main/java/org/natty/DateGroup.java
+++ b/src/main/java/org/natty/DateGroup.java
@@ -23,10 +23,11 @@ public class DateGroup {
   private Tree _syntaxTree;
 
   public DateGroup() {
-    _dates = new ArrayList<Date>();
+    _dates = new ArrayList<>();
     _isDateInferred = true;
     _isTimeInferred = true;
   }
+
 
   /**
    * Adds a date to this group

--- a/src/main/java/org/natty/Holiday.java
+++ b/src/main/java/org/natty/Holiday.java
@@ -68,7 +68,10 @@ public enum Holiday {
   /** February 14th, celebrating love and affection. */
   VALENTINES_DAY("Valentine's Day"),
   /** November 11th, honoring military veterans. */
-  VETERANS_DAY("Veteran's Day");
+  VETERANS_DAY("Veteran's Day"),
+
+  INAUGURATION_DAY("Inauguration day")
+  ;
 
   private final String summary;
   private static final Map<String, Holiday> lookup;

--- a/src/main/java/org/natty/Range.java
+++ b/src/main/java/org/natty/Range.java
@@ -86,7 +86,7 @@ public class Range<C extends Comparable<C>> implements Predicate<C> {
       final int step = forward ? 1 : -1;
       @Override
       public boolean hasNext() {
-        return current == null || (forward ? current.compareTo(end) < 0 : current.compareTo(end) > 0);
+        return current == null || end == null || (forward ? current.compareTo(end) < 0 : current.compareTo(end) > 0);
       }
 
       @Override

--- a/src/main/java/org/natty/Season.java
+++ b/src/main/java/org/natty/Season.java
@@ -7,8 +7,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import org.slf4j.Logger;
+
+import static org.slf4j.LoggerFactory.getLogger;
 
 public enum Season implements Function<Year, Instant> {
+
   /** Winter Solstice, marking the start of winter (around December 21 in the Northern Hemisphere). */
     WINTER("Winter Solstice"),
     /** Vernal Equinox, marking the start of spring (around March 20 in the Northern Hemisphere). */
@@ -18,7 +22,8 @@ public enum Season implements Function<Year, Instant> {
     /** Autumnal Equinox, marking the start of fall (around September 22 in the Northern Hemisphere). */
     FALL("Autumnal Equinox");
 
-  private final String summary;
+  private static final Logger log = getLogger(Season.class);
+
   private static final Map<String, Season> lookup;
 
   static {
@@ -29,7 +34,7 @@ public enum Season implements Function<Year, Instant> {
   }
 
 
-
+  private final String summary;
   Season(String summary) {
     this.summary = summary;
   }
@@ -178,7 +183,7 @@ public enum Season implements Function<Year, Instant> {
 
     if (year < 1000 || year > 3000) {
       // Meeus algorithm does not support years before 1000 or after 3000
-      throw new IllegalArgumentException("Year must be between 1000 and 3000");
+      log.debug("Year ({}) must be between 1000 and 3000. Result may be unprecise", year);
     }
 
 

--- a/src/main/java/org/natty/WalkerState.java
+++ b/src/main/java/org/natty/WalkerState.java
@@ -27,6 +27,7 @@ public class WalkerState {
   private static final String YEAR = "year";
   private static final String FORTNIGHT = "fortnight";
   private static final String WEEK = "week";
+  private static final String FORTNIGHT = "fortnight";
   private static final String HOUR = "hour";
   private static final String MINUTE = "minute";
   private static final String SECOND = "second";

--- a/src/main/java/org/natty/WalkerState.java
+++ b/src/main/java/org/natty/WalkerState.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
+import org.natty.eventsearchers.EventNotAvailable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +66,8 @@ public class WalkerState {
     resetCalendar();
     _dateGroup = new DateGroup();
   }
+
+
 
   public void setTimeZone(final TimeZone zone) {
     _timeZone = zone;
@@ -397,11 +400,11 @@ public class WalkerState {
    * @param direction     The direction to seek
    * @param seekAmount    The number of years to seek
    */
-  public void seekToHoliday(String holidayString, String direction, String seekAmount) {
+  public void seekToHoliday(String holidayString, String direction, String seekAmount) throws EventNotAvailable {
     Holiday holiday = Holiday.valueOf(holidayString);
     assert holiday != null;
-
     seekToEvent(holiday.getSummary(), direction, seekAmount);
+
   }
 
   /**
@@ -424,10 +427,9 @@ public class WalkerState {
    * @param direction     The direction to seek
    * @param seekAmount    The number of years to seek
    */
-  public void seekToSeason(String seasonString, String direction, String seekAmount) {
+  public void seekToSeason(String seasonString, String direction, String seekAmount) throws EventNotAvailable {
     Season season = Season.valueOf(seasonString);
     assert season!= null;
-
     seekToEvent(season.getSummary(), direction, seekAmount);
   }
 
@@ -562,7 +564,11 @@ public class WalkerState {
     }
   }
 
-  private void seekToEvent(final String eventSummary, final String direction, final String seekAmount) {
+
+  /**
+   * @throws IllegalStateException If the event cannot be found.
+   */
+  private void seekToEvent(final String eventSummary, final String direction, final String seekAmount) throws EventNotAvailable {
     final int seekAmountInt = Integer.parseInt(seekAmount);
     assert direction.equals(DIR_LEFT) || direction.equals(DIR_RIGHT);
     assert seekAmountInt >= 0;
@@ -586,8 +592,7 @@ public class WalkerState {
 
     Date currentYearDate = dates.get(currentYear);
     if (currentYearDate == null) {
-      return;
-      //throw new IllegalArgumentException("No date found for event '" + eventSummary + "' for year " + currentYear);
+      throw new EventNotAvailable("No date found for event '" + eventSummary + "' for year " + currentYear);
     }
     // grab the right one
     boolean hasPassed = cal.getTime().after(currentYearDate);
@@ -598,9 +603,7 @@ public class WalkerState {
     cal.setTimeZone(_calendar.getTimeZone());
     Date targetYearDate = dates.get(targetYear);
     if (targetYearDate == null) {
-      return;
-
-      ///  "No date found for event '" + eventSummary + "' for year " + targetYear);
+      throw new EventNotAvailable("No date found for event '" + eventSummary + "' for year " + targetYear);
     }
     cal.setTime(dates.get(targetYear));
     _calendar.set(Calendar.YEAR, cal.get(Calendar.YEAR));

--- a/src/main/java/org/natty/WalkerState.java
+++ b/src/main/java/org/natty/WalkerState.java
@@ -27,7 +27,6 @@ public class WalkerState {
   private static final String YEAR = "year";
   private static final String FORTNIGHT = "fortnight";
   private static final String WEEK = "week";
-  private static final String FORTNIGHT = "fortnight";
   private static final String HOUR = "hour";
   private static final String MINUTE = "minute";
   private static final String SECOND = "second";
@@ -250,6 +249,7 @@ public class WalkerState {
 
     if (span.equals(FORTNIGHT)) {
       seekAmountInt *= 2; // a fortnight is two weeks
+    }
     if(field > 0) {
       _calendar.add(field, seekAmountInt * sign);
     }

--- a/src/main/java/org/natty/WalkerState.java
+++ b/src/main/java/org/natty/WalkerState.java
@@ -250,7 +250,6 @@ public class WalkerState {
 
     if (span.equals(FORTNIGHT)) {
       seekAmountInt *= 2; // a fortnight is two weeks
-    }
     if(field > 0) {
       _calendar.add(field, seekAmountInt * sign);
     }

--- a/src/main/java/org/natty/WalkerState.java
+++ b/src/main/java/org/natty/WalkerState.java
@@ -19,6 +19,7 @@ public class WalkerState {
   private static final String MONTH = "month";
   private static final String DAY = "day";
   private static final String YEAR = "year";
+  private static final String FORTNIGHT = "fortnight";
   private static final String WEEK = "week";
   private static final String HOUR = "hour";
   private static final String MINUTE = "minute";
@@ -211,32 +212,38 @@ public class WalkerState {
   public void seekBySpan(String direction, String seekAmount, String span) {
     if(span.startsWith(SEEK_PREFIX)) span = span.substring(3);
     int seekAmountInt = Integer.parseInt(seekAmount);
-    assert(direction.equals(DIR_LEFT) || direction.equals(DIR_RIGHT));
-    assert(span.equals(DAY) || span.equals(WEEK) || span.equals(MONTH) ||
+    assert direction.equals(DIR_LEFT) || direction.equals(DIR_RIGHT);
+    assert span.equals(DAY) || span.equals(WEEK) || span.equals(FORTNIGHT) || span.equals(MONTH) ||
         span.equals(YEAR) || span.equals(HOUR) || span.equals(MINUTE) ||
-        span.equals(SECOND));
+        span.equals(SECOND);
 
-    boolean isDateSeek = span.equals(DAY) || span.equals(WEEK) ||
-      span.equals(MONTH) || span.equals(YEAR);
+    boolean isDateSeek = span.equals(DAY) || span.equals(WEEK) || span.equals(FORTNIGHT) || span.equals(MONTH) || span.equals(YEAR);
 
     if(isDateSeek) {
       markDateInvocation();
-    }
-    else {
+    } else {
       markTimeInvocation(null);
     }
 
     int sign = direction.equals(DIR_RIGHT) ? 1 : -1;
     int field =
       span.equals(DAY) ? Calendar.DAY_OF_YEAR :
-      span.equals(WEEK) ? Calendar.WEEK_OF_YEAR :
-      span.equals(MONTH) ? Calendar.MONTH :
-      span.equals(YEAR) ? Calendar.YEAR :
-      span.equals(HOUR) ? Calendar.HOUR:
-      span.equals(MINUTE) ? Calendar.MINUTE:
-      span.equals(SECOND) ? Calendar.SECOND:
-      null;
-    if(field > 0) _calendar.add(field, seekAmountInt * sign);
+        span.equals(WEEK) ? Calendar.WEEK_OF_YEAR :
+          span.equals(FORTNIGHT) ? Calendar.WEEK_OF_YEAR :
+
+            span.equals(MONTH) ? Calendar.MONTH :
+              span.equals(YEAR) ? Calendar.YEAR :
+                span.equals(HOUR) ? Calendar.HOUR:
+                  span.equals(MINUTE) ? Calendar.MINUTE:
+                    span.equals(SECOND) ? Calendar.SECOND:
+                      null;
+
+    if (span.equals(FORTNIGHT)) {
+      seekAmountInt *= 2; // a fortnight is two weeks
+    }
+    if(field > 0) {
+      _calendar.add(field, seekAmountInt * sign);
+    }
   }
 
   public void setDayOfWeekIndex(String index, String dayOfWeek) {

--- a/src/main/java/org/natty/WalkerState.java
+++ b/src/main/java/org/natty/WalkerState.java
@@ -237,6 +237,7 @@ public class WalkerState {
     int field =
       span.equals(DAY) ? Calendar.DAY_OF_YEAR :
         span.equals(WEEK) ? Calendar.WEEK_OF_YEAR :
+          // FORTNIGHT uses WEEK_OF_YEAR field, with seekAmount doubled below (see line 250)
           span.equals(FORTNIGHT) ? Calendar.WEEK_OF_YEAR :
 
             span.equals(MONTH) ? Calendar.MONTH :

--- a/src/main/java/org/natty/eventsearchers/AbstractYearlyHolidayEventSearcher.java
+++ b/src/main/java/org/natty/eventsearchers/AbstractYearlyHolidayEventSearcher.java
@@ -3,7 +3,6 @@ package org.natty.eventsearchers;
 import java.time.LocalDate;
 import java.time.Year;
 import java.util.Optional;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.natty.EventSearcher;
 import org.natty.Range;
@@ -20,9 +19,7 @@ public abstract class AbstractYearlyHolidayEventSearcher implements EventSearche
     if (holiday == null) {
       return Stream.empty();
     }
+     return Range.stream(range).map(holiday);
 
-    return IntStream.range(range.getStart().getValue(), range.getEnd().getValue() + 1)
-      .mapToObj(Year::of)
-      .map(holiday);
   }
 }

--- a/src/main/java/org/natty/eventsearchers/EventNotAvailable.java
+++ b/src/main/java/org/natty/eventsearchers/EventNotAvailable.java
@@ -1,0 +1,11 @@
+package org.natty.eventsearchers;
+
+/**
+ * @since 1.1
+ * @author Michiel Meeuwissen
+ */
+public class EventNotAvailable extends Exception{
+  public EventNotAvailable(String s) {
+    super(s);
+  }
+}

--- a/src/main/java/org/natty/eventsearchers/seasons/SeasonsEventSearcher.java
+++ b/src/main/java/org/natty/eventsearchers/seasons/SeasonsEventSearcher.java
@@ -2,7 +2,6 @@ package org.natty.eventsearchers.seasons;
 
 import java.time.Instant;
 import java.time.Year;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.natty.EventSearcher;
 import org.natty.Range;
@@ -20,10 +19,6 @@ public class SeasonsEventSearcher implements EventSearcher<Instant> {
     if (season == null) {
       return Stream.empty();
     }
-
-    return IntStream.range(range.getStart().getValue(), range.getEnd().getValue() + 1)
-      .mapToObj(Year::of)
-      .map(season);
-
+    return Range.stream(range).map(season);
   }
 }

--- a/src/main/java/org/natty/eventsearchers/wellknown/WellknownHoliday.java
+++ b/src/main/java/org/natty/eventsearchers/wellknown/WellknownHoliday.java
@@ -15,114 +15,110 @@ import org.natty.YearlyHoliday;
   * @author Michiel Meeuwissen
  */
 public enum WellknownHoliday implements YearlyHoliday {
-    /** April 22nd, promoting environmental protection. */
-    EARTH_DAY("Earth Day", (year) -> LocalDate.of(year.getValue(), 4, 22)),
+  /** April 22nd, promoting environmental protection. */
+  EARTH_DAY("Earth Day", (year) -> LocalDate.of(year.getValue(), 4, 22)),
 
-    /** April 1st, known for pranks and jokes. */
-    APRIL_FOOLS_DAY("April Fool's Day", (year) -> LocalDate.of(year.getValue(), 4, 1)),
+  /** April 1st, known for pranks and jokes. */
+  APRIL_FOOLS_DAY("April Fool's Day", (year) -> LocalDate.of(year.getValue(), 4, 1)),
 
-    /** Fourth Thursday in November, giving thanks and feasting. */
-    THANKSGIVING("Thanksgiving Day", (year) -> {
-        LocalDate firstDayOfNovember = LocalDate.of(year.getValue(), 11, 1);
-        int daysToAdd = (DayOfWeek.THURSDAY.getValue() - firstDayOfNovember.getDayOfWeek().getValue() + 7) % 7 + 21;
-        return firstDayOfNovember.plusDays(daysToAdd);
-    }),
+  /** Fourth Thursday in November, giving thanks and feasting. */
+  THANKSGIVING("Thanksgiving Day", (year) -> {
+    LocalDate firstDayOfNovember = LocalDate.of(year.getValue(), 11, 1);
+    int daysToAdd = (DayOfWeek.THURSDAY.getValue() - firstDayOfNovember.getDayOfWeek().getValue() + 7) % 7 + 21;
+    return firstDayOfNovember.plusDays(daysToAdd);
+  }),
 
-    /** The Friday following Thanksgiving, known for major retail sales. */
-    BLACK_FRIDAY("Black Friday", (year) -> THANKSGIVING.dateFunction.apply(year).plusDays(1)),
+  /** The Friday following Thanksgiving, known for major retail sales. */
+  BLACK_FRIDAY("Black Friday", (year) -> THANKSGIVING.dateFunction.apply(year).plusDays(1)),
 
-    /** Second Monday in October, commemorating Christopher Columbus's landing. */
-    COLUMBUS_DAY("Columbus Day (US-OPM)", (year) -> {
-        LocalDate firstDayOfOctober = LocalDate.of(year.getValue(), 10, 1);
-        int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfOctober.getDayOfWeek().getValue() + 7) % 7 + 7;
-        return firstDayOfOctober.plusDays(daysToAdd);
-    }),
+  /** Second Monday in October, commemorating Christopher Columbus's landing. */
+  COLUMBUS_DAY("Columbus Day (US-OPM)", (year) -> {
+    LocalDate firstDayOfOctober = LocalDate.of(year.getValue(), 10, 1);
+    int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfOctober.getDayOfWeek().getValue() + 7) % 7 + 7;
+    return firstDayOfOctober.plusDays(daysToAdd);
+  }),
 
-    /** February 2nd, folklore about weather prediction. */
-    GROUNDHOG_DAY("Groundhog's Day", (year) -> LocalDate.of(year.getValue(), 2, 2)),
+  /** February 2nd, folklore about weather prediction. */
+  GROUNDHOG_DAY("Groundhog's Day", (year) -> LocalDate.of(year.getValue(), 2, 2)),
 
-    /** January 1st, celebrating the start of the new year. */
-    NEW_YEARS_DAY("New Year's Day", (year) -> LocalDate.of(year.getValue(), 1, 1)),
+  /** January 1st, celebrating the start of the new year. */
+  NEW_YEARS_DAY("New Year's Day", (year) -> LocalDate.of(year.getValue(), 1, 1)),
 
-    /** December 31st, the last day of the year. */
-    NEW_YEARS_EVE("New Year's Eve", (year) -> LocalDate.of(year.getValue(), 1, 1).minusDays(1)),
+  /** December 31st, the last day of the year. */
+  NEW_YEARS_EVE("New Year's Eve", (year) -> LocalDate.of(year.getValue(), 1, 1).minusDays(1)),
 
-    /** Third Sunday in June, honoring fathers. */
-    FATHERS_DAY("Father's Day", (year) -> {
-        LocalDate firstDayOfJune = LocalDate.of(year.getValue(), 6, 1);
-        int daysToAdd = (DayOfWeek.SUNDAY.getValue() - firstDayOfJune.getDayOfWeek().getValue() + 7) % 7 + 14;
-        return firstDayOfJune.plusDays(daysToAdd);
-    }),
+  /** Third Sunday in June, honoring fathers. */
+  FATHERS_DAY("Father's Day", (year) -> {
+    LocalDate firstDayOfJune = LocalDate.of(year.getValue(), 6, 1);
+    int daysToAdd = (DayOfWeek.SUNDAY.getValue() - firstDayOfJune.getDayOfWeek().getValue() + 7) % 7 + 14;
+    return firstDayOfJune.plusDays(daysToAdd);
+  }),
 
-    /** Second Sunday in May, honoring mothers. */
-    MOTHERS_DAY("Mother's Day", (year) -> {
-        LocalDate firstDayOfMay = LocalDate.of(year.getValue(), 5, 1);
-        int daysToAdd = (DayOfWeek.SUNDAY.getValue() - firstDayOfMay.getDayOfWeek().getValue() + 7) % 7 + 7;
-        return firstDayOfMay.plusDays(daysToAdd);
-    }),
+  /** Second Sunday in May, honoring mothers. */
+  MOTHERS_DAY("Mother's Day", (year) -> {
+    LocalDate firstDayOfMay = LocalDate.of(year.getValue(), 5, 1);
+    int daysToAdd = (DayOfWeek.SUNDAY.getValue() - firstDayOfMay.getDayOfWeek().getValue() + 7) % 7 + 7;
+    return firstDayOfMay.plusDays(daysToAdd);
+  }),
 
-    /** November 11th, honoring military veterans. */
-    VETERANS_DAY("Veteran's Day", (year) -> LocalDate.of(year.getValue(), 11, 11)),
+  /** November 11th, honoring military veterans. */
+  VETERANS_DAY("Veteran's Day", (year) -> LocalDate.of(year.getValue(), 11, 11)),
 
-    /** Last Monday in May, honoring fallen military personnel. */
-    MEMORIAL_DAY("Memorial Day", (year) -> {
-        LocalDate lastDayOfMay = LocalDate.of(year.getValue(), 5, 31);
-        int daysToSubtract = (lastDayOfMay.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue() + 7) % 7;
-        return lastDayOfMay.minusDays(daysToSubtract);
-    }),
+  /** Last Monday in May, honoring fallen military personnel. */
+  MEMORIAL_DAY("Memorial Day", (year) -> {
+    LocalDate lastDayOfMay = LocalDate.of(year.getValue(), 5, 31);
+    int daysToSubtract = (lastDayOfMay.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue() + 7) % 7;
+    return lastDayOfMay.minusDays(daysToSubtract);
+  }),
 
-    /** June 14th, commemorating the adoption of the US flag. */
-    FLAG_DAY("Flag Day", (year) -> LocalDate.of(year.getValue(), 6, 14)),
+  /** June 14th, commemorating the adoption of the US flag. */
+  FLAG_DAY("Flag Day", (year) -> LocalDate.of(year.getValue(), 6, 14)),
 
-    /** October 31st, known for costumes and trick-or-treating. */
-    HALLOWEEN("Halloween", (year) -> LocalDate.of(year.getValue(), 10, 31)),
+  /** October 31st, known for costumes and trick-or-treating. */
+  HALLOWEEN("Halloween", (year) -> LocalDate.of(year.getValue(), 10, 31)),
 
-    /** July 4th, celebrating US independence. */
-    INDEPENDENCE_DAY("Independence Day", (year) -> LocalDate.of(year.getValue(), 7, 4)),
+  /** July 4th, celebrating US independence. */
+  INDEPENDENCE_DAY("Independence Day", (year) -> LocalDate.of(year.getValue(), 7, 4)),
 
-    /** December 26th, celebrating African heritage. */
-    KWANZAA("Kwanzaa", (year) -> LocalDate.of(year.getValue(), 12, 26)),
+  /** December 26th, celebrating African heritage. */
+  KWANZAA("Kwanzaa", (year) -> LocalDate.of(year.getValue(), 12, 26)),
 
-    /** First Monday in September, honoring workers. */
-    LABOR_DAY("Labor Day", (year) -> {
-        LocalDate firstDayOfSeptember = LocalDate.of(year.getValue(), 9, 1);
-        int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfSeptember.getDayOfWeek().getValue() + 7) % 7;
-        return firstDayOfSeptember.plusDays(daysToAdd);
-    }),
+  /** First Monday in September, honoring workers. */
+  LABOR_DAY("Labor Day", (year) -> {
+    LocalDate firstDayOfSeptember = LocalDate.of(year.getValue(), 9, 1);
+    int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfSeptember.getDayOfWeek().getValue() + 7) % 7;
+    return firstDayOfSeptember.plusDays(daysToAdd);
+  }),
 
-    /** Third Monday in January, honoring Martin Luther King Jr. */
-    MARTIN_LUTHER_KING_JR_DAY("Martin Luther King Jr.'s Day", (year) -> {
-        LocalDate firstDayOfJanuary = LocalDate.of(year.getValue(), 1, 1);
-        int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfJanuary.getDayOfWeek().getValue() + 7) % 7 + 14;
-        return firstDayOfJanuary.plusDays(daysToAdd);
-    }),
+  /** Third Monday in January, honoring Martin Luther King Jr. */
+  MARTIN_LUTHER_KING_JR_DAY("Martin Luther King Jr.'s Day", (year) -> {
+    LocalDate firstDayOfJanuary = LocalDate.of(year.getValue(), 1, 1);
+    int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfJanuary.getDayOfWeek().getValue() + 7) % 7 + 14;
+    return firstDayOfJanuary.plusDays(daysToAdd);
+  }),
 
-    /** September 11th, commemorating the 2001 terrorist attacks. */
-    PATRIOT_DAY("Patriot Day", (year) -> LocalDate.of(year.getValue(), 9, 11)),
+  /** September 11th, commemorating the 2001 terrorist attacks. */
+  PATRIOT_DAY("Patriot Day", (year) -> LocalDate.of(year.getValue(), 9, 11)),
 
-    /** Third Monday in February, honoring US presidents. */
-    PRESIDENTS_DAY("President's Day", (year) -> {
-        LocalDate firstDayOfFebruary = LocalDate.of(year.getValue(), 2, 1);
-        int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfFebruary.getDayOfWeek().getValue() + 7) % 7 + 14;
-        return firstDayOfFebruary.plusDays(daysToAdd);
-    }),
+  /** Third Monday in February, honoring US presidents. */
+  PRESIDENTS_DAY("President's Day", (year) -> {
+    LocalDate firstDayOfFebruary = LocalDate.of(year.getValue(), 2, 1);
+    int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfFebruary.getDayOfWeek().getValue() + 7) % 7 + 14;
+    return firstDayOfFebruary.plusDays(daysToAdd);
+  }),
 
-    /** March 17th, celebrating Irish culture and St. Patrick. */
-    ST_PATRICKS_DAY("St. Patrick's Day", (year) -> LocalDate.of(year.getValue(), 3, 17)),
+  /** March 17th, celebrating Irish culture and St. Patrick. */
+  ST_PATRICKS_DAY("St. Patrick's Day", (year) -> LocalDate.of(year.getValue(), 3, 17)),
 
-    /** April 15th, US federal income tax filing deadline. */
-    TAX_DAY("Tax Day", (year) -> LocalDate.of(year.getValue(), 4, 15)),
+  /** April 15th, US federal income tax filing deadline. */
+  TAX_DAY("Tax Day", (year) -> LocalDate.of(year.getValue(), 4, 15)),
 
-    /** First Tuesday after the first Monday in November, US general elections. */
-    ELECTION_DAY("US General Election", (year) -> {
-        LocalDate firstDayOfNovember = LocalDate.of(year.getValue(), 11, 1);
-        int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfNovember.getDayOfWeek().getValue() + 7) % 7 + 1;
-        return firstDayOfNovember.plusDays(daysToAdd);
-    }),
 
-    /** February 14th, celebrating love and affection. */
-    VALENTINES_DAY("Valentine's Day", (year) -> LocalDate.of(year.getValue(), 2, 14))
-    ;
+  /** February 14th, celebrating love and affection. */
+  VALENTINES_DAY("Valentine's Day", (year) -> LocalDate.of(year.getValue(), 2, 14))
+
+
+  ;
 
   private final String summary;
   final Function<Year, LocalDate> dateFunction;
@@ -158,4 +154,5 @@ public enum WellknownHoliday implements YearlyHoliday {
   public LocalDate apply(Year year) {
     return dateFunction.apply(year);
   }
+
 }

--- a/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHoliday.java
+++ b/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHoliday.java
@@ -1,0 +1,132 @@
+package org.natty.eventsearchers.wellknown;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Year;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+  * @since 1.1
+  * @author Michiel Meeuwissen
+ */
+public enum WellknownIrregularHoliday implements Function<Year, List<LocalDate>>{
+
+  /** First Tuesday after the first Monday in November, US general elections. */
+  ELECTION_DAY("US General Election", (year) -> {
+    LocalDate firstDayOfNovember = LocalDate.of(year.getValue(), 11, 1);
+    int daysToAdd = (DayOfWeek.MONDAY.getValue() - firstDayOfNovember.getDayOfWeek().getValue() + 7) % 7 + 1;
+    return Collections.singletonList(firstDayOfNovember.plusDays(daysToAdd));
+  }),
+
+  INAUGURATION_DAY("Inauguration Day", (year) ->  {
+    int y = year.getValue();
+    if (y < 1789) return Collections.emptyList();
+
+    // Special/irregular inaugurations (including Washington and Sunday exceptions)
+    List<LocalDate> specialInaugurations = Arrays.asList(
+      LocalDate.of(1789, 4, 30), // Washington
+      LocalDate.of(1793, 3, 4),
+      LocalDate.of(1797, 3, 4),
+      LocalDate.of(1801, 3, 4),
+      LocalDate.of(1805, 3, 4),
+      LocalDate.of(1809, 3, 4),
+      LocalDate.of(1813, 3, 4),
+      LocalDate.of(1817, 3, 4),
+      LocalDate.of(1821, 3, 5),
+      LocalDate.of(1923, 8, 3), // Harding died, Coolidge inaugurated// March 4 was Sunday
+      LocalDate.of(1825, 3, 4),
+      LocalDate.of(1829, 3, 4),
+      LocalDate.of(1833, 3, 4),
+      LocalDate.of(1837, 3, 4),
+      LocalDate.of(1841, 3, 4),
+      LocalDate.of(1845, 3, 4),
+      LocalDate.of(1849, 3, 5),  // March 4 was Sunday
+      LocalDate.of(1850, 7, 9), // Taylor died, Fillmore inaugurated
+      LocalDate.of(1853, 3, 4),
+      LocalDate.of(1857, 3, 4),
+      LocalDate.of(1861, 3, 4),
+      LocalDate.of(1865, 3, 4),
+      LocalDate.of(1865, 4, 15), // Lincoln assassinated, Johnson inaugurated
+      LocalDate.of(1869, 3, 4),
+      LocalDate.of(1873, 3, 4),
+      LocalDate.of(1877, 3, 5),  // March 4 was Sunday
+      LocalDate.of(1881, 3, 4),
+      LocalDate.of(1885, 3, 4),
+      LocalDate.of(1889, 3, 4),
+      LocalDate.of(1893, 3, 4),
+      LocalDate.of(1897, 3, 4),
+      LocalDate.of(1901, 3, 4),
+      LocalDate.of(1905, 3, 4),
+      LocalDate.of(1909, 3, 4),
+      LocalDate.of(1913, 3, 4),
+      LocalDate.of(1917, 3, 5),  // March 4 was Sunday
+      LocalDate.of(1921, 3, 4),
+      LocalDate.of(1925, 3, 4),
+      LocalDate.of(1929, 3, 4),
+      LocalDate.of(1933, 3, 4),
+      LocalDate.of(1963, 11, 22), // Kennedy assassinated, Johnson inaugurated
+      LocalDate.of(1974, 9, 8) // Nixon resigned, Ford inaugurated
+
+    );
+    List<LocalDate> result = new ArrayList<>();
+    for (LocalDate date : specialInaugurations) {
+      if (date.getYear() == y) result.add(date);
+    }
+
+    // Regular inaugurations from 1937 onward (every 4 years)
+    if (y >= 1937 && (y - 1937) % 4 == 0) {
+      LocalDate jan20 = LocalDate.of(y, 1, 20);
+      if (jan20.getDayOfWeek() == DayOfWeek.SUNDAY) {
+        result.add(jan20.plusDays(1));
+      } else {
+        result.add(jan20);
+      }
+    }
+    return result;
+  })
+  ;
+
+  private final String summary;
+  final Function<Year, List<LocalDate>> dateFunction;
+
+  private static final Map<String, WellknownIrregularHoliday> lookup;
+
+  static {
+    Map<String, WellknownIrregularHoliday> map = new HashMap<>();
+    for (WellknownIrregularHoliday h : values()) {
+      map.put(h.getSummary().toLowerCase(), h);
+    }
+    lookup = Collections.unmodifiableMap(map);
+  }
+
+  WellknownIrregularHoliday(String summary, Function<Year, List<LocalDate>> dateFunction) {
+    this.summary = summary;
+    this.dateFunction = dateFunction;
+  }
+
+  public String getSummary() {
+    return summary;
+  }
+
+  public static Optional<WellknownIrregularHoliday> fromSummary(String summary) {
+    if (summary == null || summary.trim().isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(lookup.get(summary.toLowerCase()));
+  }
+
+
+  @Override
+  public List<LocalDate> apply(Year year) {
+    return dateFunction.apply(year);
+  }
+
+
+}

--- a/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHoliday.java
+++ b/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHoliday.java
@@ -32,8 +32,6 @@ public enum WellknownIrregularHoliday implements Function<Year, List<LocalDate>>
     int y = year.getValue();
     if (y < 1789) return Collections.emptyList();
 
-
-
     List<LocalDate> d = SPECIAL_INAUGURATIONS.get(y);
     if (d != null) {
       return d;

--- a/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHoliday.java
+++ b/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHoliday.java
@@ -4,7 +4,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Year;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -12,11 +11,15 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
+import static org.natty.eventsearchers.wellknown.WellknownIrregularHolidaySearcher.SPECIAL_INAUGURATIONS;
+
 /**
   * @since 1.1
   * @author Michiel Meeuwissen
  */
 public enum WellknownIrregularHoliday implements Function<Year, List<LocalDate>>{
+
+
 
   /** First Tuesday after the first Monday in November, US general elections. */
   ELECTION_DAY("US General Election", (year) -> {
@@ -29,57 +32,13 @@ public enum WellknownIrregularHoliday implements Function<Year, List<LocalDate>>
     int y = year.getValue();
     if (y < 1789) return Collections.emptyList();
 
-    // Special/irregular inaugurations (including Washington and Sunday exceptions)
-    List<LocalDate> specialInaugurations = Arrays.asList(
-      LocalDate.of(1789, 4, 30), // Washington
-      LocalDate.of(1793, 3, 4),
-      LocalDate.of(1797, 3, 4),
-      LocalDate.of(1801, 3, 4),
-      LocalDate.of(1805, 3, 4),
-      LocalDate.of(1809, 3, 4),
-      LocalDate.of(1813, 3, 4),
-      LocalDate.of(1817, 3, 4),
-      LocalDate.of(1821, 3, 5),
-      LocalDate.of(1923, 8, 3), // Harding died, Coolidge inaugurated// March 4 was Sunday
-      LocalDate.of(1825, 3, 4),
-      LocalDate.of(1829, 3, 4),
-      LocalDate.of(1833, 3, 4),
-      LocalDate.of(1837, 3, 4),
-      LocalDate.of(1841, 3, 4),
-      LocalDate.of(1845, 3, 4),
-      LocalDate.of(1849, 3, 5),  // March 4 was Sunday
-      LocalDate.of(1850, 7, 9), // Taylor died, Fillmore inaugurated
-      LocalDate.of(1853, 3, 4),
-      LocalDate.of(1857, 3, 4),
-      LocalDate.of(1861, 3, 4),
-      LocalDate.of(1865, 3, 4),
-      LocalDate.of(1865, 4, 15), // Lincoln assassinated, Johnson inaugurated
-      LocalDate.of(1869, 3, 4),
-      LocalDate.of(1873, 3, 4),
-      LocalDate.of(1877, 3, 5),  // March 4 was Sunday
-      LocalDate.of(1881, 3, 4),
-      LocalDate.of(1885, 3, 4),
-      LocalDate.of(1889, 3, 4),
-      LocalDate.of(1893, 3, 4),
-      LocalDate.of(1897, 3, 4),
-      LocalDate.of(1901, 3, 4),
-      LocalDate.of(1905, 3, 4),
-      LocalDate.of(1909, 3, 4),
-      LocalDate.of(1913, 3, 4),
-      LocalDate.of(1917, 3, 5),  // March 4 was Sunday
-      LocalDate.of(1921, 3, 4),
-      LocalDate.of(1925, 3, 4),
-      LocalDate.of(1929, 3, 4),
-      LocalDate.of(1933, 3, 4),
-      LocalDate.of(1963, 11, 22), // Kennedy assassinated, Johnson inaugurated
-      LocalDate.of(1974, 9, 8) // Nixon resigned, Ford inaugurated
 
-    );
-    List<LocalDate> result = new ArrayList<>();
-    for (LocalDate date : specialInaugurations) {
-      if (date.getYear() == y) result.add(date);
+
+    List<LocalDate> d = SPECIAL_INAUGURATIONS.get(y);
+    if (d != null) {
+      return d;
     }
-
+    List<LocalDate> result = new ArrayList<>();
     // Regular inaugurations from 1937 onward (every 4 years)
     if (y >= 1937 && (y - 1937) % 4 == 0) {
       LocalDate jan20 = LocalDate.of(y, 1, 20);

--- a/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcher.java
+++ b/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcher.java
@@ -1,0 +1,32 @@
+package org.natty.eventsearchers.wellknown;
+
+import java.time.LocalDate;
+import java.time.Year;
+import java.util.stream.Stream;
+import org.natty.EventSearcher;
+import org.natty.Range;
+
+/**
+
+ * @since 1.1
+ * @author Michiel Meeuwissen
+ */
+public class WellknownIrregularHolidaySearcher implements EventSearcher<LocalDate> {
+
+
+  public WellknownIrregularHolidaySearcher() {
+
+  }
+
+
+
+  @Override
+  public Stream<LocalDate> findEvents(Range<Year> range, String eventSummary) {
+    WellknownIrregularHoliday holiday = WellknownIrregularHoliday.fromSummary(eventSummary)
+        .orElse(null);
+    if (holiday == null) {
+      return Stream.empty();
+    }
+     return Range.stream(range).flatMap(y -> holiday.apply(y).stream());
+  }
+}

--- a/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcher.java
+++ b/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcher.java
@@ -2,6 +2,9 @@ package org.natty.eventsearchers.wellknown;
 
 import java.time.LocalDate;
 import java.time.Year;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.natty.EventSearcher;
 import org.natty.Range;
@@ -29,4 +32,55 @@ public class WellknownIrregularHolidaySearcher implements EventSearcher<LocalDat
     }
      return Range.stream(range).flatMap(y -> holiday.apply(y).stream());
   }
+
+  // Special/irregular inaugurations (including Washington and Sunday exceptions)
+  static final Map<Integer, List<LocalDate>> SPECIAL_INAUGURATIONS = Stream.of(
+    LocalDate.of(1789, 4, 30), // Washington
+    LocalDate.of(1793, 3, 4),
+    LocalDate.of(1797, 3, 4),
+    LocalDate.of(1801, 3, 4),
+    LocalDate.of(1805, 3, 4),
+    LocalDate.of(1809, 3, 4),
+    LocalDate.of(1813, 3, 4),
+    LocalDate.of(1817, 3, 4),
+    LocalDate.of(1821, 3, 5),
+    LocalDate.of(1923, 8, 3), // Harding died, Coolidge inaugurated// March 4 was Sunday
+    LocalDate.of(1825, 3, 4),
+    LocalDate.of(1829, 3, 4),
+    LocalDate.of(1833, 3, 4),
+    LocalDate.of(1837, 3, 4),
+    LocalDate.of(1841, 3, 4),
+    LocalDate.of(1845, 3, 4),
+    LocalDate.of(1849, 3, 5),  // March 4 was Sunday
+    LocalDate.of(1850, 7, 9), // Taylor died, Fillmore inaugurated
+    LocalDate.of(1853, 3, 4),
+    LocalDate.of(1857, 3, 4),
+    LocalDate.of(1861, 3, 4),
+    LocalDate.of(1865, 3, 4),
+    LocalDate.of(1865, 4, 15), // Lincoln assassinated, Johnson inaugurated
+    LocalDate.of(1869, 3, 4),
+    LocalDate.of(1873, 3, 4),
+    LocalDate.of(1877, 3, 5),  // March 4 was Sunday
+    LocalDate.of(1881, 3, 4),
+    LocalDate.of(1885, 3, 4),
+    LocalDate.of(1889, 3, 4),
+    LocalDate.of(1893, 3, 4),
+    LocalDate.of(1897, 3, 4),
+    LocalDate.of(1901, 3, 4),
+    LocalDate.of(1905, 3, 4),
+    LocalDate.of(1909, 3, 4),
+    LocalDate.of(1913, 3, 4),
+    LocalDate.of(1917, 3, 5),  // March 4 was Sunday
+    LocalDate.of(1921, 3, 4),
+    LocalDate.of(1925, 3, 4),
+    LocalDate.of(1929, 3, 4),
+    LocalDate.of(1933, 3, 4),
+    LocalDate.of(1963, 11, 22), // Kennedy assassinated, Johnson inaugurated
+    LocalDate.of(1974, 9, 8) // Nixon resigned, Ford inaugurated
+
+  ).collect(Collectors.groupingBy(
+    LocalDate::getYear,
+    Collectors.toList()
+  ));
+
 }

--- a/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcher.java
+++ b/src/main/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcher.java
@@ -43,8 +43,8 @@ public class WellknownIrregularHolidaySearcher implements EventSearcher<LocalDat
     LocalDate.of(1809, 3, 4),
     LocalDate.of(1813, 3, 4),
     LocalDate.of(1817, 3, 4),
-    LocalDate.of(1821, 3, 5),
-    LocalDate.of(1923, 8, 3), // Harding died, Coolidge inaugurated// March 4 was Sunday
+    LocalDate.of(1821, 3, 5), // March 4 was Sunday
+    LocalDate.of(1923, 8, 3), // Harding died, Coolidge inaugurated
     LocalDate.of(1825, 3, 4),
     LocalDate.of(1829, 3, 4),
     LocalDate.of(1833, 3, 4),

--- a/src/main/resources/META-INF/services/org.natty.EventSearcher
+++ b/src/main/resources/META-INF/services/org.natty.EventSearcher
@@ -1,3 +1,4 @@
 org.natty.eventsearchers.seasons.SeasonsEventSearcher
 org.natty.eventsearchers.christian.ChristianHolidaySearcher
 org.natty.eventsearchers.wellknown.WellknownHolidaySearcher
+org.natty.eventsearchers.wellknown.WellknownIrregularHolidaySearcher

--- a/src/test/java/org/natty/AbstractTest.java
+++ b/src/test/java/org/natty/AbstractTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractTest {
    */
   protected void validateDate(Date date, int month, int day, int year) {
     _calendar.setTime(date);
-    Assert.assertEquals(date + ": month != " + month , month -1, _calendar.get(Calendar.MONTH));
+    Assert.assertEquals(date + ": month != " + month , month, _calendar.get(Calendar.MONTH) + 1);
     Assert.assertEquals(date + ": day != " + day, day, _calendar.get(Calendar.DAY_OF_MONTH));
     Assert.assertEquals(date + ": year != " + year, year, _calendar.get(Calendar.YEAR));
   }

--- a/src/test/java/org/natty/AbstractTest.java
+++ b/src/test/java/org/natty/AbstractTest.java
@@ -82,9 +82,10 @@ public abstract class AbstractTest {
    */
   protected void validateDate(Date date, int month, int day, int year) {
     _calendar.setTime(date);
+    Assert.assertEquals(date + ": year != " + year, year, _calendar.get(Calendar.YEAR));
     Assert.assertEquals(date + ": month != " + month , month, _calendar.get(Calendar.MONTH) + 1);
     Assert.assertEquals(date + ": day != " + day, day, _calendar.get(Calendar.DAY_OF_MONTH));
-    Assert.assertEquals(date + ": year != " + year, year, _calendar.get(Calendar.YEAR));
+
   }
 
   /**

--- a/src/test/java/org/natty/DateTest.java
+++ b/src/test/java/org/natty/DateTest.java
@@ -1,11 +1,11 @@
 package org.natty;
 
-import static java.util.Locale.US;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map.Entry;
 import java.util.TimeZone;
+
+import static java.util.Locale.US;
 
 
 
@@ -177,8 +179,20 @@ public class DateTest extends AbstractTest {
 
     validateDate(reference, "in 2 fortnights", 3, 28, 2011);
     validateDate(reference, "in 30 fortnights", 4, 23, 2012);
-
   }
+
+  @Test
+  public void inaugurationDay() throws ParseException {
+    Date reference = DateFormat.getDateInstance(DateFormat.SHORT, US).parse("2/28/2013");
+    validateDate(reference, "inauguration day", 1, 21, 2013);
+  }
+
+  @Test
+  public void inaugurationDay2() throws ParseException {
+    Date reference = DateFormat.getDateInstance(DateFormat.SHORT, US).parse("2/28/2011");
+    validateDate(reference, "inauguration day", 1, 21, 2013);
+  }
+
   @Test
   public void testRange() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("1/02/2011");

--- a/src/test/java/org/natty/DateTest.java
+++ b/src/test/java/org/natty/DateTest.java
@@ -1,5 +1,6 @@
 package org.natty;
 
+import static java.util.Locale.US;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -23,7 +24,7 @@ import java.util.TimeZone;
 public class DateTest extends AbstractTest {
   @BeforeClass
   public static void oneTime() {
-    Locale.setDefault(Locale.US);
+    Locale.setDefault(US);
     TimeZone.setDefault(TimeZone.getTimeZone("US/Eastern"));
     initCalendarAndParser();
   }
@@ -168,6 +169,16 @@ public class DateTest extends AbstractTest {
     validateDate(reference, "2 years 4 months 5 days ago", 10, 23, 2008);
   }
 
+  @Test
+  public void fortnight() throws Exception {
+    Date reference = DateFormat.getDateInstance(DateFormat.SHORT, US).parse("2/28/2011");
+    calendarSource = new CalendarSource(reference);
+
+
+    validateDate(reference, "in 2 fortnights", 3, 28, 2011);
+    validateDate(reference, "in 30 fortnights", 4, 23, 2012);
+
+  }
   @Test
   public void testRange() throws Exception {
     Date reference = DateFormat.getDateInstance(DateFormat.SHORT).parse("1/02/2011");

--- a/src/test/java/org/natty/DateTest.java
+++ b/src/test/java/org/natty/DateTest.java
@@ -181,15 +181,13 @@ public class DateTest extends AbstractTest {
     validateDate(reference, "in 30 fortnights", 4, 23, 2012);
   }
 
+  /**
+   * 'inauguration day' currently just finds the next inauguration day in the current year, so it actually only works in january of some years.
+   * Probably not very useful?
+   */
   @Test
   public void inaugurationDay() throws ParseException {
-    Date reference = DateFormat.getDateInstance(DateFormat.SHORT, US).parse("2/28/2013");
-    validateDate(reference, "inauguration day", 1, 21, 2013);
-  }
-
-  @Test
-  public void inaugurationDay2() throws ParseException {
-    Date reference = DateFormat.getDateInstance(DateFormat.SHORT, US).parse("2/28/2011");
+    Date reference = DateFormat.getDateInstance(DateFormat.SHORT, US).parse("1/1/2013");
     validateDate(reference, "inauguration day", 1, 21, 2013);
   }
 

--- a/src/test/java/org/natty/ParserTest.java
+++ b/src/test/java/org/natty/ParserTest.java
@@ -122,4 +122,16 @@ public class ParserTest {
 
     log.info("Parsed date: {}", parse2.get(0).getDates().get(0));
   }
+
+  @Test
+  public void issue234() {
+
+    Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
+
+    List<DateGroup> parse1 = parser.parse("While the FIFA Executive Committee is still expected to back a switch to the 2021 winter and potential clashes with the Winter Olympics, Superbowl and European soccer leagues, Mayne-Nicholls is angling for a challenge to President Sepp Blatter in next May's FIFA elections.", new Date(117, 11, 30));
+    log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
+    assertEquals("2018-05-01T23:00:00Z", parse1.get(0).getDates().get(0).toInstant().toString());
+
+  }
+
 }

--- a/src/test/java/org/natty/ParserTest.java
+++ b/src/test/java/org/natty/ParserTest.java
@@ -9,7 +9,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -149,14 +148,34 @@ public class ParserTest {
 
   }
 
+  /**
+   * inauguration day string is not present. It should just match 20 january
+   */
   @Test
-  public void issue235() {
+  public void issue235_clean() {
 
     Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
 
-    List<DateGroup> parse1 = parser.parse("Department of Justice will be blocked by the order from viewing any identifying information from third-party Facebook users who are not under investigation but viewed or interacted with a Facebook account that was used to organize Inauguration Day protests on January 20, 2017", new Date(116, Calendar.NOVEMBER, 30));
+    List<DateGroup> parse1 = parser.parse("Department of Justice will be blocked by the order from viewing any identifying information from third-party Facebook users who are not under investigation but viewed or interacted with a Facebook account that was used to organize protests on January 20, 2017", Date.from(Instant.parse("2016-11-30T00:00:00Z")));
     log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
-    assertEquals("2018-05-01T23:00:00Z", parse1.get(0).getDates().get(0).toInstant().toString());
+    assertEquals("2017-01-20T00:00:00Z", parse1.get(0).getDates().get(0).toInstant().toString());
   }
+
+
+  /**
+   * inauguration day string <em>is</em> present. But not for the current year. It should be ignored. And it should still match 20 january.
+   */
+  @Test
+  public void issue235_inauguration_day() {
+
+    Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
+
+    List<DateGroup> parse1 = parser.parse("Department of Justice will be blocked by the order from viewing any identifying information from third-party Facebook users who are not under investigation but viewed or interacted with a Facebook account that was used to organize Inauguration Day protests on January 20, 2017", Date.from(Instant.parse("2016-11-30T00:00:00Z")));
+    log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
+    assertEquals("2017-01-20T00:00:00Z", parse1.get(0).getDates().get(0).toInstant().toString());
+  }
+
+
+
 
 }

--- a/src/test/java/org/natty/ParserTest.java
+++ b/src/test/java/org/natty/ParserTest.java
@@ -7,6 +7,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
@@ -128,13 +129,12 @@ public class ParserTest {
 
   @Test
   public void issue234() {
-
     Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
 
     {
-      List<DateGroup> parse1 = parser.parse("next may", new Date(117, 11, 30));
+      List<DateGroup> parse1 = parser.parse("next may", Date.from(Instant.parse("2017-11-30T00:00:00Z")));
       log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
-      assertEquals("2018-05-01T23:00", parse1.get(0).getDates().get(0).toInstant().atZone(ZoneId.of("UTC")).toLocalDateTime().toString());
+      assertEquals("2018-05-01T00:00", parse1.get(0).getDates().get(0).toInstant().atZone(ZoneId.of("UTC")).toLocalDateTime().toString());
     }
   }
   @Test
@@ -142,9 +142,9 @@ public class ParserTest {
     Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
 
     {
-      List<DateGroup> parse1 = parser.parse("While the FIFA Executive Committee is still expected to back a switch to the 2021 winter and potential clashes with the Winter Olympics, Superbowl and European soccer leagues, Mayne-Nicholls is angling for a challenge to President Sepp Blatter in next May's FIFA elections.", new Date(117, 11, 30));
+      List<DateGroup> parse1 = parser.parse("While the FIFA Executive Committee is still expected to back a switch to the 2021 winter and potential clashes with the Winter Olympics, Superbowl and European soccer leagues, Mayne-Nicholls is angling for a challenge to President Sepp Blatter in next May's FIFA elections.", Date.from(Instant.parse("2017-11-30T00:00:00Z")));
       log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
-      //assertEquals("2018-05-01T23:00:00Z", parse1.get(0).getDates().get(0).toInstant().atZone(parser.getTimeZone().toZoneId()).toLocalDateTime().toString());
+      assertEquals("2018-05-01T00:00", parse1.get(0).getDates().get(0).toInstant().atZone(ZoneId.of("UTC")).toLocalDateTime().toString());
     }
 
   }
@@ -154,7 +154,7 @@ public class ParserTest {
 
     Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
 
-    List<DateGroup> parse1 = parser.parse("Department of Justice will be blocked by the order from viewing any identifying information from third-party Facebook users who are not under investigation but viewed or interacted with a Facebook account that was used to organize Inauguration Day protests on January 20, 2017", new Date(117, Calendar.NOVEMBER, 30));
+    List<DateGroup> parse1 = parser.parse("Department of Justice will be blocked by the order from viewing any identifying information from third-party Facebook users who are not under investigation but viewed or interacted with a Facebook account that was used to organize Inauguration Day protests on January 20, 2017", new Date(116, Calendar.NOVEMBER, 30));
     log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
     assertEquals("2018-05-01T23:00:00Z", parse1.get(0).getDates().get(0).toInstant().toString());
   }

--- a/src/test/java/org/natty/ParserTest.java
+++ b/src/test/java/org/natty/ParserTest.java
@@ -7,6 +7,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.time.ZoneId;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -17,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 public class ParserTest {
 
   private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(ParserTest.class);
+
   @Test
   public void serializationOfParser() throws IOException, ClassNotFoundException {
     // Test serializing of a basic parser which does not have a
@@ -128,10 +131,32 @@ public class ParserTest {
 
     Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
 
-    List<DateGroup> parse1 = parser.parse("While the FIFA Executive Committee is still expected to back a switch to the 2021 winter and potential clashes with the Winter Olympics, Superbowl and European soccer leagues, Mayne-Nicholls is angling for a challenge to President Sepp Blatter in next May's FIFA elections.", new Date(117, 11, 30));
+    {
+      List<DateGroup> parse1 = parser.parse("next may", new Date(117, 11, 30));
+      log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
+      assertEquals("2018-05-01T23:00", parse1.get(0).getDates().get(0).toInstant().atZone(ZoneId.of("UTC")).toLocalDateTime().toString());
+    }
+  }
+  @Test
+  public void issue234_2() {
+    Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
+
+    {
+      List<DateGroup> parse1 = parser.parse("While the FIFA Executive Committee is still expected to back a switch to the 2021 winter and potential clashes with the Winter Olympics, Superbowl and European soccer leagues, Mayne-Nicholls is angling for a challenge to President Sepp Blatter in next May's FIFA elections.", new Date(117, 11, 30));
+      log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
+      //assertEquals("2018-05-01T23:00:00Z", parse1.get(0).getDates().get(0).toInstant().atZone(parser.getTimeZone().toZoneId()).toLocalDateTime().toString());
+    }
+
+  }
+
+  @Test
+  public void issue235() {
+
+    Parser parser = new Parser(TimeZone.getTimeZone("UTC"));
+
+    List<DateGroup> parse1 = parser.parse("Department of Justice will be blocked by the order from viewing any identifying information from third-party Facebook users who are not under investigation but viewed or interacted with a Facebook account that was used to organize Inauguration Day protests on January 20, 2017", new Date(117, Calendar.NOVEMBER, 30));
     log.info("Parsed date: {}", parse1.get(0).getDates().get(0));
     assertEquals("2018-05-01T23:00:00Z", parse1.get(0).getDates().get(0).toInstant().toString());
-
   }
 
 }

--- a/src/test/java/org/natty/RangeTest.java
+++ b/src/test/java/org/natty/RangeTest.java
@@ -1,0 +1,23 @@
+package org.natty;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+
+public class RangeTest {
+
+
+  @Test
+  public void stream() {
+
+    Assert.assertEquals("[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]", Range.stream(Range.ofYears(10, 1)).collect(Collectors.toList()).toString());
+
+    Assert.assertEquals("[-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]", Range.stream(Range.ofYears(-1, 10)).collect(Collectors.toList()).toString());
+
+
+    Assert.assertEquals("[2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025, 2026]", Range.stream(Range.fromYear(2007)).limit(20).collect(Collectors.toList()).toString());
+
+  }
+}

--- a/src/test/java/org/natty/eventsearchers/WellknownHolidaysTest.java
+++ b/src/test/java/org/natty/eventsearchers/WellknownHolidaysTest.java
@@ -46,7 +46,6 @@ public class WellknownHolidaysTest {
     "President's Day on 2025-02-17",
     "St. Patrick's Day on 2025-03-17",
     "Tax Day on 2025-04-15",
-    "US General Election on 2025-11-04",
     "Valentine's Day on 2025-02-14",
     "Earth Day on 2012-04-22",
     "April Fool's Day on 2012-04-01",
@@ -70,7 +69,6 @@ public class WellknownHolidaysTest {
     "President's Day on 2012-02-20",
     "St. Patrick's Day on 2012-03-17",
     "Tax Day on 2012-04-15",
-    "US General Election on 2012-11-06",
     "Valentine's Day on 2012-02-14"
     ), strings);
   }

--- a/src/test/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcherTest.java
+++ b/src/test/java/org/natty/eventsearchers/wellknown/WellknownIrregularHolidaySearcherTest.java
@@ -1,0 +1,49 @@
+package org.natty.eventsearchers.wellknown;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.Year;
+import java.util.List;
+import org.natty.EventSearcherService;
+import org.natty.Range;
+
+
+public class WellknownIrregularHolidaySearcherTest  {
+
+
+  @Test
+  public void inaugurations() {
+
+    for (int year = 1750; year <= 2080; year++) {
+      List<LocalDate> apply = WellknownIrregularHoliday.INAUGURATION_DAY.apply(Year.of(year));
+      if (apply.isEmpty()) {
+        continue;
+      }
+      System.out.println("inauguration: " + apply);
+    }
+
+  }
+
+
+  @Test
+  public void searcher() {
+    WellknownIrregularHolidaySearcher searcher = new WellknownIrregularHolidaySearcher();
+
+    searcher.findEvents(Range.ofYears(1750, 2080), "inauguration day")
+      .forEach(System.out::println);
+
+
+  }
+
+  @Test
+  public void service() {
+
+
+    EventSearcherService.INSTANCE.findEvents(Range.ofYears(2025, 1750), "inauguration day")
+      .forEach(System.out::println);
+
+
+  }
+
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,17 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE configuration>
-
+<?xml version="1.0" ?>
 <configuration>
-    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
-    <import class="ch.qos.logback.core.ConsoleAppender"/>
+  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+  <import class="ch.qos.logback.core.ConsoleAppender"/>
 
-    <appender name="STDOUT" class="ConsoleAppender">
-        <encoder class="PatternLayoutEncoder">
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
+  <appender name="STDOUT" class="ConsoleAppender">
+    <encoder class="PatternLayoutEncoder">
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-    <root level="info">
-        <appender-ref ref="STDOUT"/>
-    </root>
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
 </configuration>


### PR DESCRIPTION
This PR adds support for parsing "fortnight" duration expressions in the Natty date parser. The change enables users to specify time periods in fortnights (2-week periods) for relative date calculations.

Adds fortnight as a recognized time span unit
Implements fortnight parsing support in the WalkerState class
Includes comprehensive test coverage for fortnight functionality

Also, it  resolves a few other issues, like #234 and #235. Things like 'inauguration day' were not working well, and even could cause exceptions.Tests for that, and fixing them too.