### PR TITLE
Support for CJK datetime format

### DIFF
--- a/src/main/antlr3/org/natty/generated/DateLexer.g
+++ b/src/main/antlr3/org/natty/generated/DateLexer.g
@@ -327,6 +327,13 @@ AUTUMN : 'autumn' 's'?;
 SPRING : 'spring' 's'?;
 SUMMER : 'summer' 's'?;
 
+
+// ********** foreign language support *********
+
+CJK_YEAR  : '\u5E74' | '\uB144' ;
+CJK_MONTH : '\u6708' | '\uC6D4' ;
+CJK_DAY   : '\u65E5' | '\uC77C' ;
+
 UNKNOWN
   : UNKNOWN_CHAR
   ;

--- a/src/main/antlr3/org/natty/generated/DateParser.g
+++ b/src/main/antlr3/org/natty/generated/DateParser.g
@@ -355,6 +355,10 @@ formal_date
   // 15-Apr-2014
   | formal_day_of_month formal_date_separator relaxed_month (formal_date_separator formal_year_four_digits)?
       -> ^(EXPLICIT_DATE relaxed_month formal_day_of_month formal_year_four_digits?)
+
+  // chinese/japanese, year first: 1979Y02M22D, 2 or 4 digit year is acceptable
+  | relaxed_day_of_week? formal_year CJK_YEAR formal_month_of_year CJK_MONTH formal_day_of_month CJK_DAY
+      -> ^(EXPLICIT_DATE formal_month_of_year formal_day_of_month relaxed_day_of_week? formal_year)
   ;
 
 formal_month_of_year

--- a/src/test/java/org/natty/DateTest.java
+++ b/src/test/java/org/natty/DateTest.java
@@ -47,6 +47,8 @@ public class DateTest extends AbstractTest {
     validateDate("28-Feb-2010", 2, 28, 2010);
     validateDate("9-Apr", 4, 9, Calendar.getInstance().get(Calendar.YEAR));
     validateDate("jan 10, '00", 1, 10, 2000);
+    validateDate("1980年3月19日", 3, 19, 1980);
+    validateDate("1980년3월19일", 3, 19, 1980);
   }
 
   @Test

--- a/src/test/java/org/natty/DateTimeTest.java
+++ b/src/test/java/org/natty/DateTimeTest.java
@@ -44,6 +44,13 @@ public class DateTimeTest extends AbstractTest {
     validateDateTime(reference, "April 20 10", 4, 20, 2012, 10, 0, 0);
     validateDateTime(reference, "April 20 at 10 am", 4, 20, 2012, 10, 0, 0);
     validateDateTime(reference, "Mar 16, 2015 3:33:39 PM", 3, 16, 2015, 15, 33, 39);
+    validateDateTime(reference, "1980年3月19日 13:00", 3, 19, 1980, 13, 0, 0);
+    validateDateTime(reference, "1980년3월19일 13:00", 3, 19, 1980, 13, 0, 0);
+    validateDateTime(reference, "5/1/13 01:00:00-8", 5, 1, 2013, 5, 0, 0);
+    validateDateTime(reference, "5/1/13 01:00:00 UTC", 4, 30, 2013, 21, 0, 0);
+    validateDateTime(reference, "5/1/13 01:00:00 UTC+8", 4, 30, 2013, 13, 0, 0);
+    validateDateTime(reference, "5/1/13 01:00:00 UTC+4:30", 4, 30, 2013, 16, 30, 0);
+    validateDateTime(reference, "5/1/13 01:00:00 GMT-1", 4, 30, 2013, 22, 0, 0);
   }
 
   @Test


### PR DESCRIPTION
Added Chinese/Japanese/Korean day/month/year characters and a formal_date parsing rule to match them.
Changes authored by Zachary Travis (co-worker of mine).